### PR TITLE
Ajout notation des histoires

### DIFF
--- a/css/features/index.css
+++ b/css/features/index.css
@@ -4,3 +4,4 @@
 @import 'notifications.css';
 @import 'cookies.css';
 @import 'user-account.css';
+@import 'notation.css';

--- a/css/features/notation.css
+++ b/css/features/notation.css
@@ -1,0 +1,3 @@
+.notation-container { text-align: center; margin-top: 30px; }
+.notation .etoile { font-size: 2rem; cursor: pointer; margin: 0 6px; user-select: none; }
+.notation .etoile:hover { transform: scale(1.2); }

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
   <script src="js/features/stories/generator.js" defer></script>
   <script src="js/features/stories/display.js" defer></script>
   <script src="js/features/stories/management.js" defer></script>
+  <script src="js/features/stories/notation.js" defer></script>
   <!-- Module de partage modulaire -->
   <script src="js/features/sharing.js" defer></script>
   <script src="js/features/sharing/notifications.js" defer></script>
@@ -246,7 +247,17 @@
     <span aria-label="Partager l'histoire" style="pointer-events:none;">🔄</span>
   </button>
 </div>
-   <div id="histoire"></div>
+  <div id="histoire"></div>
+  <div id="bloc-notation" class="notation-container hidden">
+    <p>Tu as aimé cette histoire ?</p>
+    <div class="notation">
+      <span class="etoile" data-note="1">☆</span>
+      <span class="etoile" data-note="2">☆</span>
+      <span class="etoile" data-note="3">☆</span>
+      <span class="etoile" data-note="4">☆</span>
+      <span class="etoile" data-note="5">☆</span>
+    </div>
+  </div>
 <div class="actions-resultat">
   <button id="btn-sauvegarde" class="ui-button ui-button--primary ui-mb-3">Sauvegarder</button>
   <div class="ui-button-group ui-button-group--equal">

--- a/js/core/storage.js
+++ b/js/core/storage.js
@@ -91,7 +91,8 @@ MonHistoire.core.storage = {
             contenu: data.contenu || "",
             images: data.images || [],
             partageParPrenom: data.partageParPrenom || null,
-            partageParProfil: data.partageParProfil || null
+            partageParProfil: data.partageParProfil || null,
+            note: typeof data.note === 'number' ? data.note : null
           };
           
           // Vérifier si les données sont au format tableau numéroté [0, 1, 2, 3]
@@ -235,7 +236,8 @@ MonHistoire.core.storage = {
           contenu: data.contenu || "",
           images: data.images || [],
           partageParPrenom: data.partageParPrenom || null,
-          partageParProfil: data.partageParProfil || null
+          partageParProfil: data.partageParProfil || null,
+          note: typeof data.note === 'number' ? data.note : null
         };
         
         // Vérifier si les données sont au format tableau numéroté [0, 1, 2, 3]
@@ -368,7 +370,8 @@ MonHistoire.core.storage = {
           contenu: data.contenu || "",
           images: data.images || [],
           partageParPrenom: data.partageParPrenom || null,
-          partageParProfil: data.partageParProfil || null
+          partageParProfil: data.partageParProfil || null,
+          note: typeof data.note === 'number' ? data.note : null
         };
         
         // Vérifier si les données sont au format tableau numéroté [0, 1, 2, 3]

--- a/js/features/stories/display.js
+++ b/js/features/stories/display.js
@@ -24,6 +24,9 @@ MonHistoire.features.stories.display = {
         .then(histoire => {
           // Affiche l'histoire
           this.afficherHistoire(histoire);
+          MonHistoire.features.stories.notation.afficherNote(histoire.id);
+          MonHistoire.features.stories.notation.bindNotation(histoire.id);
+          document.getElementById("bloc-notation").classList.remove("hidden");
           
           // Affiche l'écran de résultat
           MonHistoire.core.navigation.showScreen("resultat");
@@ -51,7 +54,10 @@ MonHistoire.features.stories.display = {
         .then(histoire => {
           // Affiche l'histoire
           this.afficherHistoire(histoire);
-          
+          MonHistoire.features.stories.notation.afficherNote(histoire.id);
+          MonHistoire.features.stories.notation.bindNotation(histoire.id);
+          document.getElementById("bloc-notation").classList.remove("hidden");
+
           // Affiche l'écran de résultat
           MonHistoire.core.navigation.showScreen("resultat");
           

--- a/js/features/stories/management.js
+++ b/js/features/stories/management.js
@@ -261,6 +261,18 @@ MonHistoire.features.stories.management = {
     titre.textContent = histoire.titre || "Histoire sans titre";
     titre.style.fontWeight = "bold";
     card.appendChild(titre);
+
+    if (typeof histoire.note === 'number') {
+      const notationDiv = document.createElement('div');
+      notationDiv.className = 'notation';
+      for (let i = 1; i <= 5; i++) {
+        const span = document.createElement('span');
+        span.className = 'etoile';
+        span.textContent = i <= histoire.note ? '★' : '☆';
+        notationDiv.appendChild(span);
+      }
+      card.appendChild(notationDiv);
+    }
     
     // Vérifie si l'histoire a été partagée (gère les différents formats possibles)
     const estHistoirePartagee = histoire.partageParPrenom || 

--- a/js/features/stories/notation.js
+++ b/js/features/stories/notation.js
@@ -1,0 +1,105 @@
+// js/features/stories/notation.js
+// Gestion de la notation des histoires
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.features = MonHistoire.features || {};
+MonHistoire.features.stories = MonHistoire.features.stories || {};
+
+MonHistoire.features.stories.notation = {
+  // Lit la note depuis Firestore et met à jour l'affichage des étoiles
+  async afficherNote(storyId) {
+    try {
+      const user = firebase.auth().currentUser;
+      if (!user) return;
+
+      // Déterminer le profil actif
+      let profilActif = MonHistoire.state && MonHistoire.state.profilActif;
+      if (!profilActif) {
+        profilActif = localStorage.getItem('profilActif')
+          ? JSON.parse(localStorage.getItem('profilActif'))
+          : { type: 'parent' };
+      }
+
+      // Référence du document de l'histoire
+      let docRef;
+      if (profilActif.type === 'parent') {
+        docRef = firebase.firestore()
+          .collection('users')
+          .doc(user.uid)
+          .collection('stories')
+          .doc(storyId);
+      } else {
+        docRef = firebase.firestore()
+          .collection('users')
+          .doc(user.uid)
+          .collection('profils_enfant')
+          .doc(profilActif.id)
+          .collection('stories')
+          .doc(storyId);
+      }
+
+      const doc = await docRef.get();
+      if (!doc.exists) return;
+
+      const note = doc.data().note || 0;
+      const etoiles = document.querySelectorAll('#bloc-notation .etoile');
+      etoiles.forEach(el => {
+        el.textContent = parseInt(el.dataset.note, 10) <= note ? '★' : '☆';
+      });
+    } catch (err) {
+      console.error('Erreur afficherNote:', err);
+    }
+  },
+
+  // Gère le clic sur les étoiles pour enregistrer la note
+  bindNotation(storyId) {
+    const etoiles = document.querySelectorAll('#bloc-notation .etoile');
+    etoiles.forEach(el => {
+      el.addEventListener('click', async () => {
+        const note = parseInt(el.dataset.note, 10);
+        try {
+          const user = firebase.auth().currentUser;
+          if (!user) return;
+
+          let profilActif = MonHistoire.state && MonHistoire.state.profilActif;
+          if (!profilActif) {
+            profilActif = localStorage.getItem('profilActif')
+              ? JSON.parse(localStorage.getItem('profilActif'))
+              : { type: 'parent' };
+          }
+
+          let docRef;
+          if (profilActif.type === 'parent') {
+            docRef = firebase.firestore()
+              .collection('users')
+              .doc(user.uid)
+              .collection('stories')
+              .doc(storyId);
+          } else {
+            docRef = firebase.firestore()
+              .collection('users')
+              .doc(user.uid)
+              .collection('profils_enfant')
+              .doc(profilActif.id)
+              .collection('stories')
+              .doc(storyId);
+          }
+
+          await docRef.update({ note });
+
+          etoiles.forEach(e2 => {
+            e2.textContent = parseInt(e2.dataset.note, 10) <= note ? '★' : '☆';
+          });
+
+          if (MonHistoire.core && MonHistoire.core.auth && firebase.auth().currentUser) {
+            MonHistoire.core.auth.logActivite('notation_histoire', { story_id: storyId, note });
+          }
+        } catch (err) {
+          console.error('Erreur lors de la mise à jour de la note:', err);
+        }
+      });
+    });
+  }
+};
+
+window.MonHistoire = MonHistoire;


### PR DESCRIPTION
## Summary
- add rating block in index.html and include new notation script
- style rating stars and import CSS
- implement notation module with Firestore integration
- show rating when displaying a story
- display saved story rating in list
- store note field when reading stories

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ddbecb89c832c8793dc8f55da5eb0