### PR TITLE
Reset notation when generating a new story

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ css/
 ### Modules de Fonctionnalités (features)
 
 - **audio.js** : Lecture audio des histoires (synthèse vocale)
-- **notation.js** : Gestion de la notation des histoires (étoiles et stockage Firebase)
+ - **notation.js** : Gestion de la notation des histoires (étoiles et stockage Firebase). Le module fournit une méthode `reset()` pour masquer le bloc de notation et désélectionner les étoiles lorsqu'une nouvelle histoire est générée.
 
 ### Modules de Partage (sharing)
 

--- a/js/features/stories/generator.js
+++ b/js/features/stories/generator.js
@@ -46,6 +46,14 @@ MonHistoire.features.stories.generator = {
     // Indique qu'on vient du formulaire (pour le bouton Sauvegarder)
     MonHistoire.state.resultatSource = "formulaire";
     
+    // Réinitialise la notation si disponible
+    if (MonHistoire.features &&
+        MonHistoire.features.stories &&
+        MonHistoire.features.stories.notation &&
+        typeof MonHistoire.features.stories.notation.reset === 'function') {
+      MonHistoire.features.stories.notation.reset();
+    }
+
     // Affiche l'écran de résultat
     MonHistoire.core.navigation.showScreen("resultat");
     

--- a/js/features/stories/notation.js
+++ b/js/features/stories/notation.js
@@ -147,6 +147,21 @@ MonHistoire.features.stories.notation = {
       });
     });
     console.log("[DEBUG NOTATION] Fin bindNotation");
+  },
+
+  // Réinitialise l'affichage de la notation
+  reset() {
+    console.log("[DEBUG NOTATION] Réinitialisation de la notation");
+    const blocNotation = document.getElementById('bloc-notation');
+    if (blocNotation) {
+      blocNotation.classList.add('hidden');
+    }
+
+    const etoiles = document.querySelectorAll('#bloc-notation .etoile');
+    etoiles.forEach(el => {
+      el.textContent = '☆';
+      el.classList.remove('selected');
+    });
   }
 };
 

--- a/ui-guide-style.md
+++ b/ui-guide-style.md
@@ -196,6 +196,8 @@ Le composant de notation permet aux utilisateurs d'évaluer une histoire en sél
 
 La classe `selected` est appliquée à l'étoile correspondant à la note enregistrée et déclenche une animation d'agrandissement.
 
+Lorsqu'une nouvelle histoire est générée, `generator.js` appelle `notation.reset()` pour masquer ce bloc et revenir à des étoiles non sélectionnées.
+
 ## Utilisation
 
 Pour utiliser le système UI, importez le fichier CSS principal :


### PR DESCRIPTION
## Summary
- add a reset method in `notation.js`
- call the reset from `generator.js` before showing the result screen
- document the reset behaviour in README and UI guide

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f2efad970832c9aa7ed00845c0d02