### PR TITLE
Add shake animation for new shared stories

### DIFF
--- a/css/base/animations.css
+++ b/css/base/animations.css
@@ -116,3 +116,10 @@
 .notification.animate-out {
   animation: notification-slide-out 0.5s forwards;
 }
+
+/* Animation de secousse pour les nouvelles histoires */
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-5px); }
+  40%, 80% { transform: translateX(5px); }
+}

--- a/css/components/cards.css
+++ b/css/components/cards.css
@@ -100,8 +100,13 @@
 }
 
 #liste-histoires li {
-  position: relative; 
+  position: relative;
   margin-bottom: 0.5rem;
+}
+
+/* Animation pour signaler une nouvelle histoire */
+#liste-histoires li.nouvelle-histoire {
+  animation: shake 0.6s ease-in-out 2;
 }
 
 #liste-histoires li .button,

--- a/js/core/storage.js
+++ b/js/core/storage.js
@@ -92,7 +92,8 @@ MonHistoire.core.storage = {
             images: data.images || [],
             partageParPrenom: data.partageParPrenom || null,
             partageParProfil: data.partageParProfil || null,
-            note: typeof data.note === 'number' ? data.note : null
+            note: typeof data.note === 'number' ? data.note : null,
+            nouvelleHistoire: !!data.nouvelleHistoire
           };
           
           // Vérifier si les données sont au format tableau numéroté [0, 1, 2, 3]
@@ -237,7 +238,8 @@ MonHistoire.core.storage = {
           images: data.images || [],
           partageParPrenom: data.partageParPrenom || null,
           partageParProfil: data.partageParProfil || null,
-          note: typeof data.note === 'number' ? data.note : null
+          note: typeof data.note === 'number' ? data.note : null,
+          nouvelleHistoire: !!data.nouvelleHistoire
         };
         
         // Vérifier si les données sont au format tableau numéroté [0, 1, 2, 3]
@@ -371,7 +373,8 @@ MonHistoire.core.storage = {
           images: data.images || [],
           partageParPrenom: data.partageParPrenom || null,
           partageParProfil: data.partageParProfil || null,
-          note: typeof data.note === 'number' ? data.note : null
+          note: typeof data.note === 'number' ? data.note : null,
+          nouvelleHistoire: !!data.nouvelleHistoire
         };
         
         // Vérifier si les données sont au format tableau numéroté [0, 1, 2, 3]

--- a/js/features/stories/management.js
+++ b/js/features/stories/management.js
@@ -250,6 +250,9 @@ MonHistoire.features.stories.management = {
     // Crée l'élément li qui contiendra le bouton
     const li = document.createElement("li");
     li.dataset.id = histoire.id;
+    if (histoire.nouvelleHistoire) {
+      li.classList.add("nouvelle-histoire");
+    }
     
     // Crée la carte (bouton stylisé)
     const card = document.createElement("button");


### PR DESCRIPTION
## Summary
- add animation for new stories when first viewed
- expose `nouvelleHistoire` flag in storage helpers
- apply class to new stories so they shake in the list
- define shake keyframes and styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f41d830c8832c808604a9a63d6c67