### PR TITLE
Add messaging feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,11 @@
   <script src="js/features/sharing/realtime/notifications.js" defer></script>
   <!-- Point d'entrée du module de partage -->
   <script src="js/features/sharing/index.js" defer></script>
+  <!-- Module de messagerie -->
+  <script src="js/features/messaging/storage.js" defer></script>
+  <script src="js/features/messaging/realtime.js" defer></script>
+  <script src="js/features/messaging/ui.js" defer></script>
+  <script src="js/features/messaging/index.js" defer></script>
   <script src="js/features/export.js" defer></script>
   <script src="js/features/audio.js" defer></script>
   <script src="js/features/cookies.js" defer></script>

--- a/js/app.js
+++ b/js/app.js
@@ -336,6 +336,13 @@ MonHistoire.processOfflineQueue = function() {
           MonHistoire.features.sharing.processOfflinePartage(item.data);
         }
         break;
+      case 'sendMessage':
+        if (MonHistoire.features && MonHistoire.features.messaging &&
+            MonHistoire.features.messaging.storage &&
+            typeof MonHistoire.features.messaging.storage.processOfflineMessage === 'function') {
+          MonHistoire.features.messaging.storage.processOfflineMessage(item.data);
+        }
+        break;
       // Autres types d'opérations...
     }
     
@@ -475,6 +482,10 @@ MonHistoire.init = function() {
   if (this.features && this.features.sharing) {
     console.log("[DEBUG] Initialisation du module sharing");
     this.features.sharing.init();
+  }
+  if (this.features && this.features.messaging) {
+    console.log("[DEBUG] Initialisation du module messaging");
+    this.features.messaging.init();
   }
   if (this.features && this.features.export) {
     console.log("[DEBUG] Initialisation du module export");

--- a/js/features/messaging/index.js
+++ b/js/features/messaging/index.js
@@ -1,0 +1,48 @@
+// js/features/messaging/index.js
+// Point d'entrée du module de messagerie
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.features = MonHistoire.features || {};
+MonHistoire.features.messaging = MonHistoire.features.messaging || {};
+
+(function() {
+  const messaging = MonHistoire.features.messaging;
+
+  try {
+    if (messaging.storage) {
+      messaging.storage.init && messaging.storage.init();
+    }
+    if (messaging.realtime) {
+      messaging.realtime.init && messaging.realtime.init();
+    }
+    if (messaging.ui) {
+      messaging.ui.init && messaging.ui.init();
+    }
+
+    // Exposer les fonctions principales si non présentes
+    if (!messaging.getOrCreateConversation) {
+      messaging.getOrCreateConversation = (...args) =>
+        messaging.storage.getOrCreateConversation(...args);
+    }
+    if (!messaging.sendMessage) {
+      messaging.sendMessage = (...args) =>
+        messaging.storage.sendMessage(...args);
+    }
+    if (!messaging.listenToMessages) {
+      messaging.listenToMessages = (...args) =>
+        messaging.realtime.listenToMessages(...args);
+    }
+    if (!messaging.markAsRead) {
+      messaging.markAsRead = (...args) =>
+        messaging.storage.markAsRead(...args);
+    }
+    if (!messaging.hasUnreadMessages) {
+      messaging.hasUnreadMessages = (...args) =>
+        messaging.storage.hasUnreadMessages(...args);
+    }
+
+    console.log('Module de messagerie chargé');
+  } catch (e) {
+    console.error('Erreur lors de l\'initialisation de la messagerie', e);
+  }
+})();

--- a/js/features/messaging/realtime.js
+++ b/js/features/messaging/realtime.js
@@ -1,0 +1,31 @@
+// js/features/messaging/realtime.js
+// Gestion des écouteurs en temps réel pour les messages
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.features = MonHistoire.features || {};
+MonHistoire.features.messaging = MonHistoire.features.messaging || {};
+
+MonHistoire.features.messaging.realtime = {
+  init() {
+    console.log('Module realtime messaging initialisé');
+  },
+
+  /**
+   * Écoute les messages d'une conversation en temps réel
+   * @param {string} conversationId
+   * @param {function(Object[]):void} callback
+   * @returns {function} fonction pour détacher l'écouteur
+   */
+  listenToMessages(conversationId, callback) {
+    const ref = firebase.firestore()
+      .collection('conversations').doc(conversationId)
+      .collection('messages')
+      .orderBy('createdAt');
+    const unsub = ref.onSnapshot(snap => {
+      const messages = [];
+      snap.forEach(doc => messages.push({ id: doc.id, ...doc.data() }));
+      callback(messages);
+    });
+    return unsub;
+  }
+};

--- a/js/features/messaging/storage.js
+++ b/js/features/messaging/storage.js
@@ -1,0 +1,107 @@
+// js/features/messaging/storage.js
+// Gestion du stockage des conversations et messages
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.features = MonHistoire.features || {};
+MonHistoire.features.messaging = MonHistoire.features.messaging || {};
+
+MonHistoire.features.messaging.storage = {
+  init() {
+    console.log("Module de stockage des messages initialisé");
+  },
+
+  /**
+   * Récupère ou crée une conversation pour les participants donnés
+   * @param {string[]} participants - IDs des utilisateurs participants
+   * @returns {Promise<firebase.firestore.DocumentReference>}
+   */
+  async getOrCreateConversation(participants) {
+    const hash = participants.slice().sort().join("_");
+    const convRef = firebase.firestore().collection("conversations");
+    const existing = await convRef.where("participantsHash", "==", hash).limit(1).get();
+
+    if (!existing.empty) {
+      return existing.docs[0].ref;
+    }
+
+    const docRef = await convRef.add({
+      participants: participants,
+      participantsHash: hash,
+      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+      updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+    });
+    return docRef;
+  },
+
+  /**
+   * Envoie un message dans une conversation
+   * @param {string} conversationId - ID de la conversation
+   * @param {string} contenu - texte du message
+   */
+  async sendMessage(conversationId, contenu) {
+    const user = firebase.auth().currentUser;
+    if (!user) {
+      MonHistoire.showMessageModal && MonHistoire.showMessageModal("Tu dois être connecté pour envoyer un message.");
+      return false;
+    }
+
+    const messageData = {
+      senderId: user.uid,
+      content: contenu,
+      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+      readBy: [user.uid],
+      deviceId: MonHistoire.generateDeviceId(),
+      version: 1
+    };
+
+    if (!MonHistoire.state.isConnected) {
+      if (typeof MonHistoire.addToOfflineQueue === 'function') {
+        MonHistoire.addToOfflineQueue('sendMessage', { conversationId, messageData });
+        return true;
+      }
+    }
+
+    await firebase.firestore()
+      .collection('conversations').doc(conversationId)
+      .collection('messages').add(messageData);
+
+    await firebase.firestore().collection('conversations').doc(conversationId).update({
+      lastMessage: contenu,
+      updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+    });
+    return true;
+  },
+
+  /** Traite l'envoi d'un message qui était en file d'attente hors ligne */
+  async processOfflineMessage(data) {
+    try {
+      const { conversationId, messageData } = data;
+      await firebase.firestore()
+        .collection('conversations').doc(conversationId)
+        .collection('messages').add({ ...messageData, processedOffline: true });
+      await firebase.firestore().collection('conversations').doc(conversationId).update({
+        lastMessage: messageData.content,
+        updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+      });
+      return true;
+    } catch (e) {
+      console.error("Erreur lors du traitement du message hors ligne", e);
+      return false;
+    }
+  },
+
+  async markAsRead(conversationId, messageId, userId) {
+    const ref = firebase.firestore().collection('conversations')
+      .doc(conversationId).collection('messages').doc(messageId);
+    await ref.update({
+      readBy: firebase.firestore.FieldValue.arrayUnion(userId)
+    });
+  },
+
+  async hasUnreadMessages(conversationId, userId) {
+    const snap = await firebase.firestore()
+      .collection('conversations').doc(conversationId)
+      .collection('messages').get();
+    return snap.docs.some(d => !(d.data().readBy || []).includes(userId));
+  }
+};

--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -1,0 +1,12 @@
+// js/features/messaging/ui.js
+// Interface utilisateur pour la messagerie
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.features = MonHistoire.features || {};
+MonHistoire.features.messaging = MonHistoire.features.messaging || {};
+
+MonHistoire.features.messaging.ui = {
+  init() {
+    console.log('Module UI messaging initialisé');
+  }
+};


### PR DESCRIPTION
## Summary
- add basic messaging modules mirroring the sharing feature
- register messaging feature during app startup
- handle offline message queue
- include messaging scripts in index.html

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684f56ed82b0832c88549ca853ba8d4c