### PR TITLE
Add Firestore messaging rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,3 +451,8 @@ MonHistoire.debug("Message de débogage", data);
 ## Conclusion
 
 Cette nouvelle architecture modulaire offre une base solide pour le développement futur de l'application "Mon Histoire". Elle facilite la maintenance, l'évolution et la collaboration entre développeurs.
+
+## Déploiement
+
+Les règles de sécurité Firestore destinées à la messagerie se trouvent dans le fichier `firestore.messaging.rules` à la racine du projet. Veillez à inclure ce fichier lors du déploiement sur Firebase.
+

--- a/firestore.messaging.rules
+++ b/firestore.messaging.rules
@@ -1,0 +1,4 @@
+match /conversations/{cid} {
+  allow read, write: if request.auth != null &&
+    request.auth.uid in resource.data.users.map(id => id.split(":")[0]);
+}


### PR DESCRIPTION
## Summary
- add `firestore.messaging.rules` security file
- document Firebase rules deployment in README

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684f56f31fb0832cac6a2b0d4921a935