### PR TITLE
Document message storage in privacy policy

### DIFF
--- a/backup-pre-refactorisation/index.html
+++ b/backup-pre-refactorisation/index.html
@@ -425,12 +425,18 @@
         <h3>Politique de confidentialité</h3>
         <div style="text-align:left; font-size:0.98em;">
           <p>
-            Ici figurera la politique de confidentialité et les informations sur la gestion des données personnelles.<br>
-            <b>(Texte à compléter plus tard !)</b>
+            Notre application enregistre les messages que vous rédigez ainsi que les métadonnées de vos conversations
+            (dates, heures, identifiant de profil, etc.). Ces informations sont stockées dans Firebase afin de vous
+            permettre de retrouver votre historique et d'améliorer le service.
           </p>
-          <ul>
-            <li>Suppression ou rectification de vos données : <a href="mailto:support@monhistoire.fr">support@monhistoire.fr</a></li>
-          </ul>
+          <p>
+            Les messages et leurs métadonnées sont conservés tant que votre compte reste actif ou jusqu'à ce que vous
+            demandiez leur suppression.
+          </p>
+          <p>
+            Vous pouvez accéder à vos messages ou demander leur effacement à tout moment en nous contactant&nbsp;:
+            <a href="mailto:support@monhistoire.fr">support@monhistoire.fr</a>
+          </p>
         </div>
       </div>
       

--- a/index.html
+++ b/index.html
@@ -475,12 +475,18 @@
         <h3>Politique de confidentialité</h3>
         <div style="text-align:left; font-size:0.98em;">
           <p>
-            Ici figurera la politique de confidentialité et les informations sur la gestion des données personnelles.<br>
-            <b>(Texte à compléter plus tard !)</b>
+            Notre application enregistre les messages que vous rédigez ainsi que les métadonnées de vos conversations
+            (dates, heures, identifiant de profil, etc.). Ces informations sont stockées dans Firebase afin de vous
+            permettre de retrouver votre historique et d'améliorer le service.
           </p>
-          <ul>
-            <li>Suppression ou rectification de vos données : <a href="mailto:support@monhistoire.fr">support@monhistoire.fr</a></li>
-          </ul>
+          <p>
+            Les messages et leurs métadonnées sont conservés tant que votre compte reste actif ou jusqu'à ce que vous
+            demandiez leur suppression.
+          </p>
+          <p>
+            Vous pouvez accéder à vos messages ou demander leur effacement à tout moment en nous contactant&nbsp;:
+            <a href="mailto:support@monhistoire.fr">support@monhistoire.fr</a>
+          </p>
         </div>
       </div>
       

--- a/index.html.backup
+++ b/index.html.backup
@@ -459,12 +459,18 @@ const firebaseConfig = {
         <h3>Politique de confidentialité</h3>
         <div style="text-align:left; font-size:0.98em;">
           <p>
-            Ici figurera la politique de confidentialité et les informations sur la gestion des données personnelles.<br>
-            <b>(Texte à compléter plus tard !)</b>
+            Notre application enregistre les messages que vous rédigez ainsi que les métadonnées de vos conversations
+            (dates, heures, identifiant de profil, etc.). Ces informations sont stockées dans Firebase afin de vous
+            permettre de retrouver votre historique et d'améliorer le service.
           </p>
-          <ul>
-            <li>Suppression ou rectification de vos données : <a href="mailto:support@monhistoire.fr">support@monhistoire.fr</a></li>
-          </ul>
+          <p>
+            Les messages et leurs métadonnées sont conservés tant que votre compte reste actif ou jusqu'à ce que vous
+            demandiez leur suppression.
+          </p>
+          <p>
+            Vous pouvez accéder à vos messages ou demander leur effacement à tout moment en nous contactant&nbsp;:
+            <a href="mailto:support@monhistoire.fr">support@monhistoire.fr</a>
+          </p>
         </div>
       </div>
       


### PR DESCRIPTION
## Summary
- expand the content of the RGPD modal's privacy tab
- mention message storage and retention
- describe how to request access or deletion of messages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f56f73458832cbe32a02498a6a5b1