### PR TITLE
Add conditions and legal modals with footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,6 +441,8 @@
   
 <footer style="text-align:center; margin:2em 0; opacity:0.7;">
   <a href="#" id="link-rgpd" style="font-size:1rem; margin-right: 1em;">Vie privée &amp; RGPD</a>
+  <a href="#" id="link-conditions" style="font-size:1rem; margin-right: 1em;">Conditions d’utilisation</a>
+  <a href="#" id="link-legal" style="font-size:1rem; margin-right: 1em;">Mentions légales</a>
   <a href="#" id="cookie-settings-link" style="font-size:1rem;">Paramètres des cookies</a>
 </footer>
 <!-- Modale de renommage de profil enfant -->
@@ -596,6 +598,27 @@
   </div>
 </div>
 
+<div class="ui-modal" id="modal-conditions">
+  <div class="ui-modal-content ui-modal-content--large ui-card--cream" style="max-width:500px;">
+    <span class="ui-modal-close" onclick="document.getElementById('modal-conditions').classList.remove('show')">×</span>
+    <h3>Conditions d’utilisation</h3>
+    <p style="text-align:left; font-size:0.98em;">Le texte complet des conditions d’utilisation sera disponible prochainement.</p>
+    <div class="ui-button-group ui-button-group--center" style="margin-top: 20px;">
+      <button class="ui-button ui-button--secondary" onclick="document.getElementById('modal-conditions').classList.remove('show')">Fermer</button>
+    </div>
+  </div>
+</div>
+
+<div class="ui-modal" id="modal-legal">
+  <div class="ui-modal-content ui-modal-content--large ui-card--cream" style="max-width:500px;">
+    <span class="ui-modal-close" onclick="document.getElementById('modal-legal').classList.remove('show')">×</span>
+    <h3>Mentions légales</h3>
+    <p style="text-align:left; font-size:0.98em;">Les mentions légales complètes seront ajoutées prochainement.</p>
+    <div class="ui-button-group ui-button-group--center" style="margin-top: 20px;">
+      <button class="ui-button ui-button--secondary" onclick="document.getElementById('modal-legal').classList.remove('show')">Fermer</button>
+    </div>
+  </div>
+</div>
 
 <!-- Bannière de consentement aux cookies -->
 <div id="cookie-banner" class="cookie-banner">

--- a/js/app.js
+++ b/js/app.js
@@ -614,6 +614,22 @@ document.addEventListener('DOMContentLoaded', function() {
       document.getElementById('modal-rgpd').classList.add('show');
     };
   }
+
+  const conditionsLink = document.getElementById('link-conditions');
+  if (conditionsLink) {
+    conditionsLink.onclick = function(e) {
+      e.preventDefault();
+      document.getElementById('modal-conditions').classList.add('show');
+    };
+  }
+
+  const legalLink = document.getElementById('link-legal');
+  if (legalLink) {
+    legalLink.onclick = function(e) {
+      e.preventDefault();
+      document.getElementById('modal-legal').classList.add('show');
+    };
+  }
   
   // Nous ne définissons pas d'écouteur d'événement ici pour éviter les conflits
   // L'écouteur est défini dans js/ui.js ou js/modules/ui/common.js


### PR DESCRIPTION
## Summary
- add footer links to conditions of use and legal notices
- create modal dialogs for those pages with placeholder text
- wire up new footer links via event handlers

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f56fa0b64832c8d04f8a1f98cb775