### PR TITLE
Implement basic messaging interface

### DIFF
--- a/css/features/index.css
+++ b/css/features/index.css
@@ -5,3 +5,4 @@
 @import 'cookies.css';
 @import 'user-account.css';
 @import 'notation.css';
+@import 'messaging.css';

--- a/css/features/messaging.css
+++ b/css/features/messaging.css
@@ -1,0 +1,59 @@
+/* css/features/messaging.css */
+
+#modal-messages .conversation-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #fff7eb;
+  border-radius: 12px;
+  padding: 0.6em 1em;
+  margin-bottom: 0.5em;
+  cursor: pointer;
+}
+
+#modal-messages .conversation-item.unread {
+  font-weight: bold;
+}
+
+#modal-conversation {
+  display: flex;
+  flex-direction: column;
+}
+
+#conversation-messages {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 60vh;
+  padding: 1em 0;
+}
+
+.message-bubble {
+  max-width: 70%;
+  padding: 0.5em 0.8em;
+  margin: 0.4em;
+  border-radius: 16px;
+  line-height: 1.4;
+}
+
+.message-bubble.sent {
+  background: #79d4e7;
+  color: #395872;
+  margin-left: auto;
+}
+
+.message-bubble.received {
+  background: #d5b8f6;
+  color: #5c4683;
+  margin-right: auto;
+}
+
+#zone-saisie-message {
+  display: flex;
+  gap: 0.5em;
+  margin-top: 0.5em;
+}
+
+#zone-saisie-message input {
+  flex: 1;
+}
+

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
         <button class="ui-button ui-button--primary ui-button--medium" id="create-button" data-screen="formulaire">Créer une histoire</button>
         <button class="ui-button ui-button--secondary ui-button--medium" id="login-button" data-screen="connexion">Me connecter</button>
         <button class="ui-button ui-button--secondary ui-button--medium ui-hidden" id="my-stories-button" data-screen="mes-histoires">Mes Histoires</button>
+        <button class="ui-button ui-button--secondary ui-button--medium ui-hidden" id="my-messages-button">Mes messages</button>
       </div>
     </div>
     <div id="user-icon" class="ui-hidden"></div>
@@ -460,6 +461,27 @@
       <button class="ui-button ui-button--secondary" id="btn-annuler-renommer-profil">Annuler</button>
       <button class="ui-button ui-button--primary" id="btn-confirmer-renommer-profil">Valider</button>
     </div>
+</div>
+</div>
+
+<div class="ui-modal" id="modal-messages">
+  <div class="ui-modal-content ui-modal-content--medium ui-card--cream">
+    <h3 class="ui-text-center">Mes messages</h3>
+    <div id="liste-conversations"></div>
+    <button id="btn-nouveau-message" class="ui-button ui-button--primary ui-mt-3">+ Nouveau message</button>
+    <button id="btn-fermer-messages" class="ui-button ui-button--secondary ui-mt-3">Fermer</button>
+  </div>
+</div>
+
+<div class="ui-modal" id="modal-conversation">
+  <div class="ui-modal-content ui-modal-content--medium ui-card--cream" style="display:flex; flex-direction:column;">
+    <h3 id="conversation-contact" class="ui-text-center"></h3>
+    <div id="conversation-messages"></div>
+    <div id="zone-saisie-message">
+      <input id="input-message" class="ui-input" type="text" placeholder="Ton message..." />
+      <button id="btn-envoyer-message" class="ui-button ui-button--primary">Envoyer</button>
+    </div>
+    <button id="btn-fermer-conversation" class="ui-button ui-button--secondary ui-mt-3">Fermer</button>
   </div>
 </div>
 

--- a/js/core/auth.js
+++ b/js/core/auth.js
@@ -170,6 +170,11 @@ MonHistoire.core.auth = {
     document.getElementById("user-icon").classList.remove("ui-hidden");
     document.getElementById("login-button").classList.add("ui-hidden");
     document.getElementById("my-stories-button").classList.remove("ui-hidden");
+    if (MonHistoire.state.profilActif.type === "enfant" && MonHistoire.state.profilActif.acces_messagerie === false) {
+      document.getElementById("my-messages-button").classList.add("ui-hidden");
+    } else {
+      document.getElementById("my-messages-button").classList.remove("ui-hidden");
+    }
 
     // → Si un profil enfant est actif, on court-circuite tout :
     if (MonHistoire.state.profilActif.type === "enfant") {
@@ -209,6 +214,7 @@ MonHistoire.core.auth = {
     document.getElementById("user-icon").classList.add("ui-hidden");
     document.getElementById("login-button").classList.remove("ui-hidden");
     document.getElementById("my-stories-button").classList.add("ui-hidden");
+    document.getElementById("my-messages-button").classList.add("ui-hidden");
   },
   
   // Ouvre la modale de déconnexion

--- a/js/core/profiles.js
+++ b/js/core/profiles.js
@@ -134,10 +134,12 @@ MonHistoire.core.profiles = {
       }
       
       // Le profil existe, on peut continuer
+      const data = profilDoc.data() || {};
       return this.changerProfil({
         type: "enfant",
         id: id,
-        prenom: prenom
+        prenom: prenom,
+        acces_messagerie: data.acces_messagerie !== false
       });
     } catch (error) {
       console.error("Erreur lors du changement de profil:", error);

--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -5,8 +5,106 @@ window.MonHistoire = window.MonHistoire || {};
 MonHistoire.features = MonHistoire.features || {};
 MonHistoire.features.messaging = MonHistoire.features.messaging || {};
 
-MonHistoire.features.messaging.ui = {
-  init() {
+MonHistoire.features.messaging.ui = (function() {
+  let currentConversationId = null;
+  let unsubscribe = null;
+
+  function init() {
     console.log('Module UI messaging initialisé');
+
+    document.getElementById('my-messages-button')?.addEventListener('click', openConversationsModal);
+    document.getElementById('btn-fermer-messages')?.addEventListener('click', closeConversationsModal);
+    document.getElementById('btn-fermer-conversation')?.addEventListener('click', closeConversation);
+    document.getElementById('btn-envoyer-message')?.addEventListener('click', sendCurrentMessage);
   }
-};
+
+  async function openConversationsModal() {
+    const user = firebase.auth().currentUser;
+    if (!user) return;
+
+    const list = document.getElementById('liste-conversations');
+    if (!list) return;
+    list.innerHTML = '';
+
+    const snap = await firebase.firestore()
+      .collection('conversations')
+      .where('participants', 'array-contains', user.uid)
+      .orderBy('updatedAt', 'desc')
+      .get();
+
+    snap.forEach(doc => {
+      const data = doc.data();
+      const other = (data.participants || []).find(p => p !== user.uid) || '';
+      const prenom = other.split(':')[1] || other;
+
+      const item = document.createElement('div');
+      item.className = 'conversation-item';
+      item.textContent = prenom + ' \u2013 ' + (data.lastMessage || '');
+
+      messaging.storage.hasUnreadMessages(doc.id, user.uid).then(unread => {
+        if (unread) item.classList.add('unread');
+      });
+
+      item.onclick = () => openConversation(doc.id, prenom);
+      list.appendChild(item);
+    });
+
+    document.getElementById('modal-messages').classList.add('show');
+  }
+
+  function closeConversationsModal() {
+    document.getElementById('modal-messages').classList.remove('show');
+  }
+
+  function closeConversation() {
+    document.getElementById('modal-conversation').classList.remove('show');
+    unsubscribe && unsubscribe();
+    unsubscribe = null;
+    currentConversationId = null;
+  }
+
+  function openConversation(id, prenom) {
+    const container = document.getElementById('conversation-messages');
+    if (!container) return;
+    container.innerHTML = '';
+
+    document.getElementById('conversation-contact').textContent = prenom;
+    document.getElementById('modal-conversation').classList.add('show');
+
+    currentConversationId = id;
+    unsubscribe && unsubscribe();
+    unsubscribe = messaging.listenToMessages(id, msgs => {
+      container.innerHTML = '';
+      msgs.forEach(m => {
+        const div = document.createElement('div');
+        div.className = 'message-bubble ' + (m.senderId === firebase.auth().currentUser.uid ? 'sent' : 'received');
+        div.textContent = m.content;
+        container.appendChild(div);
+        if (!(m.readBy || []).includes(firebase.auth().currentUser.uid)) {
+          messaging.markAsRead(id, m.id, firebase.auth().currentUser.uid);
+        }
+      });
+      container.scrollTop = container.scrollHeight;
+    });
+  }
+
+  async function sendCurrentMessage() {
+    const input = document.getElementById('input-message');
+    if (!input || !currentConversationId) return;
+    const text = input.value.trim();
+    if (!text) return;
+    await messaging.sendMessage(currentConversationId, text);
+    input.value = '';
+  }
+
+  const messaging = MonHistoire.features.messaging;
+
+  return {
+    init,
+    openConversationsModal,
+    closeConversationsModal,
+    openConversation,
+    closeConversation,
+    sendCurrentMessage
+  };
+})();


### PR DESCRIPTION
## Summary
- add messaging styles and import them
- add UI elements and modals to manage messages
- handle messaging access in profiles and auth logic
- implement messaging UI logic
- wire up new buttons and events

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68502bf6dd58832ca8b61fdf1820df04