### PR TITLE
Update messaging rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Cette nouvelle architecture modulaire offre une base solide pour le développeme
 
 ## Déploiement
 
-Les règles de sécurité Firestore destinées à la messagerie se trouvent dans le fichier `firestore.messaging.rules` à la racine du projet. Veillez à inclure ce fichier lors du déploiement sur Firebase.
+Les règles de sécurité Firestore destinées à la messagerie se trouvent dans le fichier `firestore.messaging.rules` à la racine du projet. Veillez à inclure ce fichier lors du déploiement sur Firebase. Ce fichier vérifie que `request.auth.uid` est présent dans `resource.data.participants` (les identifiants sont séparés par `:` pour extraire l'UID).
 
 Le fichier `firestore.indexes.json` contient la définition des index composites nécessaires à l'application. Déployez-le à l'aide de la commande :
 

--- a/firestore.messaging.rules
+++ b/firestore.messaging.rules
@@ -1,4 +1,5 @@
 match /conversations/{cid} {
   allow read, write: if request.auth != null &&
-    request.auth.uid in resource.data.users.map(id => id.split(":")[0]);
+    request.auth.uid in resource.data.participants
+      .map(id => id.split(":")[0]);
 }


### PR DESCRIPTION
## Summary
- use `participants` array in Firestore messaging rules
- describe participant-based validation in README

## Testing
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68508205f8d8832cae6473e65a7c34bd