### PR TITLE
Fix mobile messaging input width

### DIFF
--- a/css/features/messaging.css
+++ b/css/features/messaging.css
@@ -20,6 +20,12 @@
   flex-direction: column;
 }
 
+#modal-conversation .ui-modal-content {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5em;
+}
+
 #conversation-messages {
   flex: 1;
   overflow-y: auto;
@@ -51,9 +57,11 @@
   display: flex;
   gap: 0.5em;
   margin-top: 0.5em;
+  width: 100%;
 }
 
-#zone-saisie-message input {
+#input-message {
   flex: 1;
+  min-width: 0;
 }
 


### PR DESCRIPTION
## Summary
- ensure the conversation modal keeps a column layout
- make message input responsive

## Testing
- `npm install puppeteer` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850820d9014832c97400e53df7a0574