### PR TITLE
Fix messaging input layout

### DIFF
--- a/css/features/messaging.css
+++ b/css/features/messaging.css
@@ -55,6 +55,7 @@
 
 #zone-saisie-message {
   display: flex;
+  flex-direction: column;
   gap: 0.5em;
   margin-top: 0.5em;
   width: 100%;
@@ -63,5 +64,10 @@
 #input-message {
   flex: 1;
   min-width: 0;
+  width: 100%;
+}
+
+#zone-saisie-message button {
+  width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- stack message input and send button vertically
- ensure both elements fill width of their container

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68508f3deeb8832c9781c005cc6e5869