### PR TITLE
Fix event listener duplication

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -184,9 +184,6 @@ MonHistoire.ui = {
     document.getElementById("btn-fermer-conversation")?.addEventListener("click", () => {
       MonHistoire.features.messaging.ui.closeConversation();
     });
-    document.getElementById("btn-envoyer-message")?.addEventListener("click", () => {
-      MonHistoire.features.messaging.ui.sendCurrentMessage();
-    });
     
     
     // Bouton Connexion


### PR DESCRIPTION
## Summary
- remove redundant messaging button handler from `js/ui.js`
- check that messaging module continues to bind its own listener

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68508f41c49c832c9bbce41fdb935089