### PR TITLE
Improve messaging modal scrolling

### DIFF
--- a/css/features/messaging.css
+++ b/css/features/messaging.css
@@ -77,3 +77,13 @@
   overflow-y: auto;
 }
 
+#modal-messages .ui-modal-content {
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+#liste-conversations {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+


### PR DESCRIPTION
## Summary
- keep message modals within viewport
- allow conversations list to scroll smoothly

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6850fea72878832c9a07187111e44d01