### PR TITLE
Add confirmation before removing child profiles

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -941,6 +941,16 @@ MonHistoire.ui = {
       return;
     }
     
+    // Demander confirmation si des suppressions sont prévues
+    const hasDeletion = MonHistoire.state.profilsEnfantModifies.some(m => m.action === "supprimer");
+    if (hasDeletion) {
+      const confirmMessage =
+        "Supprimer ce profil effacera définitivement toutes les discussions associées. Continuer ?";
+      if (!confirm(confirmMessage)) {
+        return; // Annuler si l'utilisateur ne confirme pas
+      }
+    }
+
     // Créer un batch pour les opérations Firestore
     const batch = firebase.firestore().batch();
     const ref = firebase.firestore().collection("users").doc(user.uid).collection("profils_enfant");


### PR DESCRIPTION
## Summary
- prompt for confirmation before deleting a child profile because linked discussions will be deleted

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850feaf885c832cb26eed0c3debcdc8