### PR TITLE
Update messaging docs and privacy notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ css/
 - **notifications.js** : Gestion des notifications de partage
 - **storage.js** : Stockage des données de partage
 
+### Modules de Messagerie (messaging)
+
+- **storage.js** : Gestion des conversations et envoi des messages via Firestore
+- **realtime.js** : Écoute en temps réel des nouveaux messages
+- **ui.js** : Affichage de la liste des conversations et de la fenêtre de discussion
+
 ### Système de notation des histoires
 
 La fonctionnalité de notation permet aux utilisateurs d'évaluer une histoire en sélectionnant de 1 à 5 étoiles. Le bloc de notation est affiché dans l'écran de résultat et la note est enregistrée dans Firestore. Le module `notation.js` fournit les méthodes :
@@ -107,6 +113,44 @@ La fonctionnalité de notation permet aux utilisateurs d'évaluer une histoire e
 - `afficherNote(id)` : lit la note depuis Firestore et met à jour l'affichage.
 - `bindNotation(id)` : ajoute les événements de clic sur les étoiles pour sauvegarder la note.
 - `reset()` : réinitialise l'affichage (étoiles non sélectionnées et bloc masqué).
+
+## Messagerie
+
+La messagerie permet aux utilisateurs parent et enfant de discuter en toute sécurité.
+Elle s'appuie sur trois modules :
+
+- **storage.js** : accès à Firestore pour créer ou récupérer une conversation et enregistrer les messages.
+- **realtime.js** : mise en place des écouteurs en temps réel sur les messages.
+- **ui.js** : affichage des conversations et des bulles de messages dans l'interface.
+
+### API principale
+
+```javascript
+messaging.getOrCreateConversation(participants);
+messaging.sendMessage(conversationId, contenu);
+messaging.listenToMessages(conversationId, cb);
+messaging.markAsRead(conversationId, messageId, userKey);
+messaging.hasUnreadMessages(conversationId, userKey);
+```
+
+### Schéma Firestore
+
+```
+conversations
+  └─ {conversationId}
+       ├─ participants: [uid:type]
+       ├─ participantsHash: string
+       ├─ lastMessage: string
+       ├─ createdAt / updatedAt
+       └─ messages
+            └─ {messageId}
+                 ├─ senderId: uid:type
+                 ├─ content: string
+                 ├─ createdAt: timestamp
+                 └─ readBy: [uid:type]
+```
+
+Les règles de sécurité se trouvent dans `firestore.messaging.rules` et les index nécessaires dans `firestore.indexes.json`.
 
 ## Schéma d'Architecture Détaillé
 

--- a/index.html
+++ b/index.html
@@ -512,12 +512,12 @@
         <div style="text-align:left; font-size:0.98em;">
           <p>
             Notre application enregistre les messages que vous rédigez ainsi que les métadonnées de vos conversations
-            (dates, heures, identifiant de profil, etc.). Ces informations sont stockées dans Firebase afin de vous
+            (dates, heures, identifiant de profil, etc.). Ces informations sont stockées dans Firebase Firestore afin de vous
             permettre de retrouver votre historique et d'améliorer le service.
           </p>
           <p>
-            Les messages et leurs métadonnées sont conservés tant que votre compte reste actif ou jusqu'à ce que vous
-            demandiez leur suppression.
+            Les messages et leurs métadonnées sont conservés tant que votre compte reste actif. La suppression d'un profil enfant
+            entraîne également l'effacement de tous les messages associés. Vous pouvez aussi demander leur suppression à tout moment.
           </p>
           <p>
             Vous pouvez accéder à vos messages ou demander leur effacement à tout moment en nous contactant&nbsp;:
@@ -550,6 +550,7 @@
         <p>Ces cookies permettent d'améliorer les fonctionnalités et la personnalisation de notre application.</p>
         <ul>
           <li><strong>Firebase Firestore Cache</strong> : Stocke temporairement vos données pour améliorer les performances et permettre l'utilisation hors ligne.</li>
+          <li><strong>Firebase Firestore (conversations)</strong> : Conserve les métadonnées de vos conversations (participants, dernier message) pour afficher l'historique.</li>
           <li><strong>Stockage local (localStorage)</strong> : Bien que techniquement différent des cookies, nous stockons certaines préférences comme votre profil actif et le prénom du héros de vos histoires.</li>
           <li><strong>Durée de conservation</strong> : Jusqu'à effacement manuel ou désinstallation de l'application</li>
         </ul>


### PR DESCRIPTION
## Summary
- document messaging modules and API
- clarify privacy policy about messages
- note Firestore usage in cookie policy

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850feb14fa8832cb71abd4b8e891988