### PR TITLE
Ameliore modales de messagerie

### DIFF
--- a/css/features/messaging.css
+++ b/css/features/messaging.css
@@ -11,6 +11,10 @@
   cursor: pointer;
 }
 
+#modal-messages .conversation-item strong {
+  font-weight: bold;
+}
+
 #modal-messages .conversation-item.unread {
   font-weight: bold;
 }
@@ -24,6 +28,8 @@
   display: flex;
   flex-direction: column;
   padding: 1.5em;
+  max-height: 80vh;
+  overflow-y: hidden;
 }
 
 #conversation-messages {
@@ -45,12 +51,14 @@
   background: #79d4e7;
   color: #395872;
   margin-left: auto;
+  text-align: right;
 }
 
 .message-bubble.received {
   background: #d5b8f6;
   color: #5c4683;
   margin-right: auto;
+  text-align: left;
 }
 
 #zone-saisie-message {
@@ -79,10 +87,13 @@
 
 #modal-messages .ui-modal-content {
   max-height: 80vh;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow-y: hidden;
 }
 
 #liste-conversations {
+  flex: 1;
   max-height: 60vh;
   overflow-y: auto;
 }

--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -72,7 +72,7 @@ MonHistoire.features.messaging.ui = (function() {
 
       const item = document.createElement('div');
       item.className = 'conversation-item';
-      item.textContent = '... \u2013 ' + (data.lastMessage || '');
+      item.innerHTML = '<strong>...</strong> \u2013 ' + (data.lastMessage || '');
       list.appendChild(item);
 
       messaging.storage.hasUnreadMessages(doc.id, selfKey).then(unread => {
@@ -80,11 +80,11 @@ MonHistoire.features.messaging.ui = (function() {
       });
 
       fetchPrenom(other).then(prenom => {
-        item.textContent = prenom + ' \u2013 ' + (data.lastMessage || '');
+        item.innerHTML = '<strong>' + prenom + '</strong> \u2013 ' + (data.lastMessage || '');
         item.onclick = () => openConversation(doc.id, prenom);
       }).catch(() => {
         const prenom = other.split(':')[1] || other;
-        item.textContent = prenom + ' \u2013 ' + (data.lastMessage || '');
+        item.innerHTML = '<strong>' + prenom + '</strong> \u2013 ' + (data.lastMessage || '');
         item.onclick = () => openConversation(doc.id, prenom);
       });
     });


### PR DESCRIPTION
## Summary
- limite la hauteur de la modale de discussion
- maintient les boutons visibles lors du scroll
- aligne droite/gauche les bulles envoyées ou reçues
- affiche le prénom en gras dans la liste des conversations

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685132fa59b4832cb215f2b06453d12e