### PR TITLE
Add messaging notifications and badges

### DIFF
--- a/css/features/messaging.css
+++ b/css/features/messaging.css
@@ -9,6 +9,7 @@
   padding: 0.6em 1em;
   margin-bottom: 0.5em;
   cursor: pointer;
+  position: relative;
 }
 
 #modal-messages .conversation-item strong {
@@ -96,5 +97,13 @@
   flex: 1;
   max-height: 60vh;
   overflow-y: auto;
+}
+
+.conversation-item .notification-indicator {
+  top: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  font-size: 11px;
 }
 

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
   <script src="js/features/messaging/storage.js" defer></script>
   <script src="js/features/messaging/realtime.js" defer></script>
   <script src="js/features/messaging/ui.js" defer></script>
+  <script src="js/features/messaging/notifications.js" defer></script>
   <script src="js/features/messaging/index.js" defer></script>
   <script src="js/features/export.js" defer></script>
   <script src="js/features/audio.js" defer></script>

--- a/js/features/messaging/index.js
+++ b/js/features/messaging/index.js
@@ -19,6 +19,9 @@ MonHistoire.features.messaging = MonHistoire.features.messaging || {};
       if (messaging.ui && typeof messaging.ui.init === 'function') {
         messaging.ui.init();
       }
+      if (messaging.notifications && typeof messaging.notifications.init === 'function') {
+        messaging.notifications.init();
+      }
 
       // Exposer les fonctions principales si non présentes
       if (!messaging.getOrCreateConversation) {
@@ -40,6 +43,10 @@ MonHistoire.features.messaging = MonHistoire.features.messaging || {};
       if (!messaging.hasUnreadMessages) {
         messaging.hasUnreadMessages = (...args) =>
           messaging.storage.hasUnreadMessages(...args);
+      }
+      if (!messaging.markConversationRead) {
+        messaging.markConversationRead = (...args) =>
+          messaging.notifications.markConversationRead(...args);
       }
 
       console.log('Module de messagerie initialisé');

--- a/js/features/messaging/notifications.js
+++ b/js/features/messaging/notifications.js
@@ -1,0 +1,144 @@
+// js/features/messaging/notifications.js
+// Gestion des notifications de messages
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.features = MonHistoire.features || {};
+MonHistoire.features.messaging = MonHistoire.features.messaging || {};
+
+MonHistoire.features.messaging.notifications = (function() {
+  let unreadByConversation = {};
+  let unreadByProfile = {};
+
+  function init() {
+    console.log('Module notifications messaging initialisé');
+
+    // Écouteurs d'événements
+    if (MonHistoire.events && typeof MonHistoire.events.on === 'function') {
+      MonHistoire.events.on('profilChange', recalculerMessagesNonLus);
+      MonHistoire.events.on('authStateChange', user => {
+        if (user) {
+          recalculerMessagesNonLus();
+        } else {
+          unreadByConversation = {};
+          unreadByProfile = {};
+          mettreAJourBadgeMessages();
+          mettreAJourBadgeConversations();
+        }
+      });
+      MonHistoire.events.on('messageCreated', recalculerMessagesNonLus);
+    }
+
+    // Recalcul initial si l'utilisateur est déjà authentifié
+    if (firebase.auth().currentUser) {
+      recalculerMessagesNonLus();
+    }
+  }
+
+  async function recalculerMessagesNonLus() {
+    try {
+      const user = firebase.auth().currentUser;
+      if (!user) return;
+      const profil = (MonHistoire.state && MonHistoire.state.profilActif) ||
+        (localStorage.getItem('profilActif') ? JSON.parse(localStorage.getItem('profilActif')) : { type: 'parent' });
+      const selfKey = `${user.uid}:${profil.type === 'parent' ? 'parent' : profil.id}`;
+
+      unreadByConversation = {};
+      unreadByProfile = {};
+
+      const convSnap = await firebase.firestore()
+        .collection('conversations')
+        .where('participants', 'array-contains', selfKey)
+        .get();
+
+      for (const doc of convSnap.docs) {
+        let count = 0;
+        const messagesSnap = await doc.ref.collection('messages').get();
+        messagesSnap.forEach(m => {
+          const readBy = m.data().readBy || [];
+          if (!(readBy.includes(selfKey) || readBy.includes(user.uid))) count++;
+        });
+        if (count > 0) {
+          unreadByConversation[doc.id] = count;
+          const other = (doc.data().participants || []).find(p => p !== selfKey && p !== user.uid) || doc.id;
+          unreadByProfile[other] = (unreadByProfile[other] || 0) + count;
+        }
+      }
+      mettreAJourBadgeMessages();
+      mettreAJourBadgeConversations();
+      if (MonHistoire.events && typeof MonHistoire.events.emit === 'function') {
+        MonHistoire.events.emit('messageNotificationUpdate', {
+          byConversation: unreadByConversation,
+          byProfile: unreadByProfile
+        });
+      }
+    } catch (e) {
+      console.error('Erreur lors du recalcul des messages non lus', e);
+    }
+  }
+
+  function mettreAJourBadgeMessages() {
+    const total = Object.values(unreadByProfile).reduce((a, b) => a + b, 0);
+    const btn = document.getElementById('my-messages-button');
+    if (!btn) return;
+    let badge = btn.querySelector('.notification-indicator') || btn.querySelector('.ui-notification-badge');
+    if (total > 0) {
+      if (!badge) {
+        badge = document.createElement('span');
+        badge.className = 'notification-indicator ui-notification-badge';
+        btn.appendChild(badge);
+      }
+      badge.textContent = total > 9 ? '9+' : total.toString();
+      badge.style.display = 'flex';
+    } else if (badge) {
+      badge.style.display = 'none';
+    }
+  }
+
+  function mettreAJourBadgeConversations() {
+    const items = document.querySelectorAll('.conversation-item');
+    items.forEach(item => {
+      const convId = item.dataset.conversationId;
+      const count = convId && unreadByConversation[convId] ? unreadByConversation[convId] : 0;
+      let badge = item.querySelector('.notification-indicator') || item.querySelector('.ui-notification-badge');
+      if (count > 0) {
+        if (!badge) {
+          badge = document.createElement('span');
+          badge.className = 'notification-indicator ui-notification-badge';
+          item.appendChild(badge);
+        }
+        badge.textContent = count > 9 ? '9+' : count.toString();
+        badge.style.display = 'flex';
+      } else if (badge) {
+        badge.style.display = 'none';
+      }
+    });
+  }
+
+  function markConversationRead(conversationId) {
+    if (unreadByConversation[conversationId]) {
+      const count = unreadByConversation[conversationId];
+      delete unreadByConversation[conversationId];
+      // retirer du total par profil
+      Object.keys(unreadByProfile).forEach(k => {
+        unreadByProfile[k] -= count;
+        if (unreadByProfile[k] <= 0) delete unreadByProfile[k];
+      });
+      mettreAJourBadgeMessages();
+      mettreAJourBadgeConversations();
+      if (MonHistoire.events && typeof MonHistoire.events.emit === 'function') {
+        MonHistoire.events.emit('messageNotificationUpdate', {
+          byConversation: unreadByConversation,
+          byProfile: unreadByProfile
+        });
+      }
+    }
+  }
+
+  return {
+    init,
+    recalculerMessagesNonLus,
+    mettreAJourBadgeMessages,
+    mettreAJourBadgeConversations,
+    markConversationRead
+  };
+})();

--- a/js/features/messaging/storage.js
+++ b/js/features/messaging/storage.js
@@ -86,6 +86,9 @@ MonHistoire.features.messaging.storage = {
     if (!MonHistoire.state.isConnected) {
       if (typeof MonHistoire.addToOfflineQueue === 'function') {
         MonHistoire.addToOfflineQueue('sendMessage', { conversationId, messageData });
+        if (MonHistoire.events && typeof MonHistoire.events.emit === 'function') {
+          MonHistoire.events.emit('messageCreated', { conversationId });
+        }
         return true;
       }
     }
@@ -98,6 +101,9 @@ MonHistoire.features.messaging.storage = {
       lastMessage: contenu,
       updatedAt: firebase.firestore.FieldValue.serverTimestamp()
     });
+    if (MonHistoire.events && typeof MonHistoire.events.emit === 'function') {
+      MonHistoire.events.emit('messageCreated', { conversationId });
+    }
     return true;
   },
 
@@ -112,6 +118,9 @@ MonHistoire.features.messaging.storage = {
         lastMessage: messageData.content,
         updatedAt: firebase.firestore.FieldValue.serverTimestamp()
       });
+      if (MonHistoire.events && typeof MonHistoire.events.emit === 'function') {
+        MonHistoire.events.emit('messageCreated', { conversationId });
+      }
       return true;
     } catch (e) {
       console.error("Erreur lors du traitement du message hors ligne", e);

--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -72,12 +72,9 @@ MonHistoire.features.messaging.ui = (function() {
 
       const item = document.createElement('div');
       item.className = 'conversation-item';
+      item.dataset.conversationId = doc.id;
       item.innerHTML = '<strong>...</strong> \u2013 ' + (data.lastMessage || '');
       list.appendChild(item);
-
-      messaging.storage.hasUnreadMessages(doc.id, selfKey).then(unread => {
-        if (unread) item.classList.add('unread');
-      });
 
       fetchPrenom(other).then(prenom => {
         item.innerHTML = '<strong>' + prenom + '</strong> \u2013 ' + (data.lastMessage || '');
@@ -88,6 +85,8 @@ MonHistoire.features.messaging.ui = (function() {
         item.onclick = () => openConversation(doc.id, prenom);
       });
     });
+
+    messaging.notifications.mettreAJourBadgeConversations();
 
     document.getElementById('modal-messages').classList.add('show');
   }
@@ -132,6 +131,7 @@ MonHistoire.features.messaging.ui = (function() {
       });
       container.scrollTop = container.scrollHeight;
     });
+    messaging.notifications.markConversationRead(id);
   }
 
   async function startNewConversation() {
@@ -218,6 +218,7 @@ MonHistoire.features.messaging.ui = (function() {
     const text = input.value.trim();
     if (!text) return;
     await messaging.sendMessage(currentConversationId, text);
+    messaging.notifications.markConversationRead(currentConversationId);
     input.value = '';
   }
 


### PR DESCRIPTION
## Summary
- add notifications module for messaging
- expose notifications in messaging index and emit message events from storage
- update UI to mark conversations read and show badges
- style conversation badges
- include new script in index.html

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851402ea26c832ca769a64c3929c998