### PR TITLE
Add unread messaging API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ messaging.listenToMessages(conversationId, cb);
 messaging.markAsRead(conversationId, messageId, userKey);
 messaging.hasUnreadMessages(conversationId, userKey);
 ```
+- `messaging.listenToUnreadMessages()` : écoute les conversations de l'utilisateur pour détecter les nouveaux messages non lus.
+- `messaging.detachUnreadListeners()` : retire tous les écouteurs créés par `listenToUnreadMessages()`.
 
 ### Schéma Firestore
 


### PR DESCRIPTION
## Summary
- document `messaging.listenToUnreadMessages()` and `messaging.detachUnreadListeners()` in the messaging API section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685160fc57bc832cb73fddb3d82b3bfc