### PR TITLE
Fix unread counts for legacy conversations

### DIFF
--- a/js/features/messaging/notifications.js
+++ b/js/features/messaging/notifications.js
@@ -46,12 +46,15 @@ MonHistoire.features.messaging.notifications = (function() {
       unreadByConversation = {};
       unreadByProfile = {};
 
-      const convSnap = await firebase.firestore()
-        .collection('conversations')
-        .where('participants', 'array-contains', selfKey)
-        .get();
+      const convRef = firebase.firestore().collection('conversations');
+      const docsMap = {};
+      const snapNew = await convRef.where('participants', 'array-contains', selfKey).get();
+      snapNew.forEach(d => docsMap[d.id] = d);
+      const snapOld = await convRef.where('participants', 'array-contains', user.uid).get();
+      snapOld.forEach(d => { if (!docsMap[d.id]) docsMap[d.id] = d; });
+      const convDocs = Object.values(docsMap);
 
-      for (const doc of convSnap.docs) {
+      for (const doc of convDocs) {
         let count = 0;
         const messagesSnap = await doc.ref.collection('messages').get();
         messagesSnap.forEach(m => {


### PR DESCRIPTION
## Summary
- merge old and new conversation queries when counting unread messages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685164afda54832c88325a79b726d789