### PR TITLE
Fix badge positioning on messages button

### DIFF
--- a/css/features/messaging.css
+++ b/css/features/messaging.css
@@ -107,3 +107,8 @@
   font-size: 11px;
 }
 
+/* Permet au badge de notification de se positionner correctement */
+#my-messages-button {
+  position: relative;
+}
+


### PR DESCRIPTION
## Summary
- make `#my-messages-button` relative so notification badge shows in the right corner

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685164b538b8832c9e44f3f2c71dd004