### PR TITLE
Add detailed messaging logs

### DIFF
--- a/js/features/messaging/index.js
+++ b/js/features/messaging/index.js
@@ -49,9 +49,17 @@ MonHistoire.features.messaging = MonHistoire.features.messaging || {};
           messaging.notifications.markConversationRead(...args);
       }
 
-      console.log('Module de messagerie initialisé');
+      if (MonHistoire.logger) {
+        MonHistoire.logger.info('MESSAGING', 'Module de messagerie initialisé');
+      } else {
+        console.log('Module de messagerie initialisé');
+      }
     } catch (e) {
-      console.error('Erreur lors de l\'initialisation de la messagerie', e);
+      if (MonHistoire.logger) {
+        MonHistoire.logger.error('MESSAGING', "Erreur lors de l'initialisation de la messagerie", e);
+      } else {
+        console.error('Erreur lors de l\'initialisation de la messagerie', e);
+      }
     }
   };
 })();

--- a/js/features/messaging/storage.js
+++ b/js/features/messaging/storage.js
@@ -64,6 +64,7 @@ MonHistoire.features.messaging.storage = {
    */
   async sendMessage(conversationId, contenu) {
     const user = firebase.auth().currentUser;
+    MonHistoire.logger && MonHistoire.logger.debug('MESSAGING', 'Envoi message', { conversationId });
     if (!user) {
       MonHistoire.showMessageModal && MonHistoire.showMessageModal("Tu dois être connecté pour envoyer un message.");
       return false;
@@ -104,6 +105,7 @@ MonHistoire.features.messaging.storage = {
     if (MonHistoire.events && typeof MonHistoire.events.emit === 'function') {
       MonHistoire.events.emit('messageCreated', { conversationId });
     }
+    MonHistoire.logger && MonHistoire.logger.debug('MESSAGING', 'Message envoyé', { conversationId });
     return true;
   },
 
@@ -111,6 +113,7 @@ MonHistoire.features.messaging.storage = {
   async processOfflineMessage(data) {
     try {
       const { conversationId, messageData } = data;
+      MonHistoire.logger && MonHistoire.logger.debug('MESSAGING', 'Traitement message hors ligne', { conversationId });
       await firebase.firestore()
         .collection('conversations').doc(conversationId)
         .collection('messages').add({ ...messageData, processedOffline: true });
@@ -121,9 +124,14 @@ MonHistoire.features.messaging.storage = {
       if (MonHistoire.events && typeof MonHistoire.events.emit === 'function') {
         MonHistoire.events.emit('messageCreated', { conversationId });
       }
+      MonHistoire.logger && MonHistoire.logger.debug('MESSAGING', 'Message hors ligne traité', { conversationId });
       return true;
     } catch (e) {
-      console.error("Erreur lors du traitement du message hors ligne", e);
+      if (MonHistoire.logger) {
+        MonHistoire.logger.error('MESSAGING', 'Erreur lors du traitement du message hors ligne', e);
+      } else {
+        console.error("Erreur lors du traitement du message hors ligne", e);
+      }
       return false;
     }
   },


### PR DESCRIPTION
## Summary
- add logging to messaging notifications
- log messaging realtime events
- log messaging init and storage actions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851674fd9c4832c9d413f4b73625874