### PR TITLE
Update readBy usage in messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,13 @@ conversations
                  ├─ senderId: uid:type
                  ├─ content: string
                  ├─ createdAt: timestamp
-                 └─ readBy: [uid:type]
+                 └─ readBy: [profilKey]
 ```
+
+`readBy` stocke la clé de profil (`uid:profilId` ou `uid:parent`) pour chaque
+utilisateur ayant lu le message. Pour les anciens messages ne contenant que
+l'UID simple, celui-ci n'est pris en compte que si aucune clé de profil n'est
+présente dans le tableau.
 
 Les règles de sécurité se trouvent dans `firestore.messaging.rules` et les index nécessaires dans `firestore.indexes.json`.
 

--- a/js/features/messaging/notifications.js
+++ b/js/features/messaging/notifications.js
@@ -75,7 +75,9 @@ MonHistoire.features.messaging.notifications = (function() {
         const messagesSnap = await doc.ref.collection('messages').get();
         messagesSnap.forEach(m => {
           const readBy = m.data().readBy || [];
-          if (!(readBy.includes(selfKey) || readBy.includes(user.uid))) count++;
+          const hasProfileKeys = readBy.some(v => v.includes(':'));
+          const isRead = readBy.includes(selfKey) || (!hasProfileKeys && readBy.includes(user.uid));
+          if (!isRead) count++;
         });
         if (count > 0) {
           unreadByConversation[doc.id] = count;

--- a/js/features/messaging/realtime.js
+++ b/js/features/messaging/realtime.js
@@ -117,7 +117,9 @@ MonHistoire.features.messaging.realtime = {
         if (change.type === 'added') {
           const data = change.doc.data();
           const readBy = data.readBy || [];
-          if (!(readBy.includes(selfKey) || readBy.includes(selfKey.split(':')[0]))) {
+          const hasProfileKeys = readBy.some(v => v.includes(':'));
+          const isRead = readBy.includes(selfKey) || (!hasProfileKeys && readBy.includes(selfKey.split(':')[0]));
+          if (!isRead) {
             MonHistoire.logger && MonHistoire.logger.debug('MESSAGING', 'Nouveau message reçu', { conversationId, id: change.doc.id });
             if (MonHistoire.events && typeof MonHistoire.events.emit === 'function') {
               MonHistoire.events.emit('messageReceived', {

--- a/js/features/messaging/storage.js
+++ b/js/features/messaging/storage.js
@@ -79,7 +79,8 @@ MonHistoire.features.messaging.storage = {
       senderId: senderKey,
       content: contenu,
       createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-      readBy: [senderKey, user.uid],
+      // `readBy` ne stocke que la clé de profil de l'expéditeur
+      readBy: [senderKey],
       deviceId: MonHistoire.generateDeviceId(),
       version: 1
     };
@@ -139,8 +140,9 @@ MonHistoire.features.messaging.storage = {
   async markAsRead(conversationId, messageId, userId) {
     const ref = firebase.firestore().collection('conversations')
       .doc(conversationId).collection('messages').doc(messageId);
+    // On enregistre uniquement la clé de profil dans readBy
     await ref.update({
-      readBy: firebase.firestore.FieldValue.arrayUnion(userId, userId.split(':')[0])
+      readBy: firebase.firestore.FieldValue.arrayUnion(userId)
     });
   },
 


### PR DESCRIPTION
## Summary
- store only the profile key in `readBy`
- update realtime and notification checks for legacy messages
- document the new behaviour in README

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685173b477b4832c8d4b61aa250e2b1c