### PR TITLE
Handle messageNotificationUpdate in UI

### DIFF
--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -39,6 +39,14 @@ MonHistoire.features.messaging.ui = (function() {
     document.getElementById('btn-envoyer-message')?.addEventListener('click', sendCurrentMessage);
     document.getElementById('btn-nouveau-message')?.addEventListener('click', startNewConversation);
     document.getElementById('btn-fermer-nouveau-message')?.addEventListener('click', closeNewMessageModal);
+
+    // Met à jour les badges lorsqu'un événement de notification est émis
+    if (MonHistoire.events && typeof MonHistoire.events.on === 'function') {
+      MonHistoire.events.on('messageNotificationUpdate', () => {
+        messaging.notifications.mettreAJourBadgeMessages();
+        messaging.notifications.mettreAJourBadgeConversations();
+      });
+    }
   }
 
   async function openConversationsModal() {


### PR DESCRIPTION
## Summary
- update `messaging.ui` to listen for `messageNotificationUpdate`
- when the event triggers, refresh conversation and message badges

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68517fc3e21c832cb2bd89b52fde2e4d