### PR TITLE
Improve placeholder for fetchPrenom errors

### DIFF
--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -8,6 +8,7 @@ MonHistoire.features.messaging = MonHistoire.features.messaging || {};
 MonHistoire.features.messaging.ui = (function() {
   let currentConversationId = null;
   let unsubscribe = null;
+  const UNKNOWN_PRENOM = 'Inconnu';
 
   async function fetchPrenom(key) {
     const [uid, part] = key.split(':');
@@ -26,7 +27,7 @@ MonHistoire.features.messaging.ui = (function() {
       return snap.exists && snap.data().prenom ? snap.data().prenom : part;
     } catch (e) {
       console.error('Erreur lors de la récupération du prénom', e);
-      return part;
+      return UNKNOWN_PRENOM;
     }
   }
 


### PR DESCRIPTION
## Summary
- provide a default `UNKNOWN_PRENOM` label in messaging UI
- return this placeholder if fetching a first name fails

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68517fc6c568832c94e971641e683aae