### PR TITLE
Handle failed prenom fetch in conversations list

### DIFF
--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -97,7 +97,7 @@ MonHistoire.features.messaging.ui = (function() {
         item.innerHTML = '<strong>' + prenom + '</strong> \u2013 ' + (data.lastMessage || '');
         item.onclick = () => openConversation(doc.id, prenom);
       }).catch(() => {
-        const prenom = other.split(':')[1] || other;
+        const prenom = 'Inconnu';
         item.innerHTML = '<strong>' + prenom + '</strong> \u2013 ' + (data.lastMessage || '');
         item.onclick = () => openConversation(doc.id, prenom);
       });


### PR DESCRIPTION
## Summary
- handle errors when fetching prenom by showing `Inconnu`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685187ccf340832ca46ef3d94ddbcd9b