### PR TITLE
Handle fetchPrenom errors in UI

### DIFF
--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -34,8 +34,9 @@ MonHistoire.features.messaging.ui = (function() {
       return prenom;
     } catch (e) {
       console.error('Erreur lors de la récupération du prénom', e);
-      prenomCache.set(key, part);
-      return part;
+      // Use a placeholder when fetching the name fails
+      prenomCache.set(key, 'Inconnu');
+      return 'Inconnu';
     }
   }
 


### PR DESCRIPTION
## Summary
- return fallback `Inconnu` if fetchPrenom fails
- document placeholder use in `js/features/messaging/ui.js`

## Testing
- `npm test` *(fails: Missing script and npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685187ce0948832c96f8e4b2ca09578c