### PR TITLE
Add Jest test for fetchPrenom

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ npm start
 
 Le serveur démarre sur http://localhost:3000.
 
+## Tests
+
+```bash
+npm test
+```
+
+Les tests utilisent [Jest](https://jestjs.io/). Aucune configuration particulière n'est nécessaire.
+
 ## Architecture Modulaire
 
 L'application a été restructurée selon une architecture modulaire où chaque module est responsable d'une fonctionnalité spécifique. Cette approche offre plusieurs avantages :

--- a/js/features/messaging/ui.js
+++ b/js/features/messaging/ui.js
@@ -34,8 +34,8 @@ MonHistoire.features.messaging.ui = (function() {
       return prenom;
     } catch (e) {
       console.error('Erreur lors de la récupération du prénom', e);
-      prenomCache.set(key, part);
-      return part;
+      prenomCache.set(key, 'Inconnu');
+      return 'Inconnu';
     }
   }
 
@@ -240,6 +240,10 @@ MonHistoire.features.messaging.ui = (function() {
   }
 
   const messaging = MonHistoire.features.messaging;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { fetchPrenom };
+  }
 
   return {
     init,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Application web Mon Histoire",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1"
   }
 }

--- a/tests/fetchPrenom.test.js
+++ b/tests/fetchPrenom.test.js
@@ -1,0 +1,15 @@
+const { fetchPrenom } = require('../js/features/messaging/ui');
+
+describe('fetchPrenom', () => {
+  test('returns "Inconnu" when the Firestore call throws', async () => {
+    const dummyDoc = {
+      collection: jest.fn(() => dummyDoc),
+      doc: jest.fn(() => dummyDoc),
+      get: jest.fn(() => Promise.reject(new Error('fail')))
+    };
+    global.firebase = { firestore: jest.fn(() => dummyDoc) };
+
+    const result = await fetchPrenom('uid:parent');
+    expect(result).toBe('Inconnu');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest as dev dependency and `npm test` script
- modify `fetchPrenom` to return `Inconnu` on error and expose it for tests
- document running tests in README
- create Jest unit test for error case

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685187d0dd44832cb975fe764fbc6b6f