### PR TITLE
Add firebase cleanup after fetchPrenom tests

### DIFF
--- a/tests/fetchPrenom.test.js
+++ b/tests/fetchPrenom.test.js
@@ -1,0 +1,20 @@
+const { JSDOM } = require('jsdom');
+
+// Mock firebase globally
+beforeAll(() => {
+  global.firebase = {
+    firestore: jest.fn(),
+    auth: jest.fn()
+  };
+});
+
+afterAll(() => {
+  // Clean up global firebase between test runs
+  delete global.firebase;
+});
+
+describe('fetchPrenom placeholder test', () => {
+  test('sample', () => {
+    expect(typeof global.firebase).toBe('object');
+  });
+});


### PR DESCRIPTION
## Summary
- add `tests/fetchPrenom.test.js` including `afterAll()` hook that removes `global.firebase`

## Testing
- `npm test` *(fails: Missing script)*
- `node tests/fetchPrenom.test.js` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68518ea5ec24832caf3d22f9f04749ae