### PR TITLE
Update Firestore message schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ conversations
                  ├─ senderId: uid:type
                  ├─ content: string
                  ├─ createdAt: timestamp
+                 ├─ deviceId: string
+                 ├─ version: number
+                 ├─ processedOffline: boolean
                  └─ readBy: [profilKey]
 ```
 
@@ -156,6 +159,8 @@ conversations
 utilisateur ayant lu le message. Pour les anciens messages ne contenant que
 l'UID simple, celui-ci n'est pris en compte que si aucune clé de profil n'est
 présente dans le tableau.
+
+Les champs `deviceId` et `version` servent à identifier les messages mis en attente hors ligne. Lorsque l'utilisateur n'est pas connecté, l'envoi est enregistré dans une file locale avec ces informations. À la reconnexion, `MonHistoire.processOfflineQueue()` lit cette file et crée le message dans Firestore en ajoutant `processedOffline: true`.
 
 Les règles de sécurité se trouvent dans `firestore.messaging.rules` et les index nécessaires dans `firestore.indexes.json`.
 


### PR DESCRIPTION
## Summary
- document `deviceId`, `version` and `processedOffline` fields in the Firestore
  message schema
- explain how offline operations queue uses these fields and reference
  `MonHistoire.processOfflineQueue()`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851994098c0832cbca2a24dfe6f9fbe