### PR TITLE
Fix navigation after logout

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -559,6 +559,9 @@ MonHistoire.init = function() {
     } else {
       if (MonHistoire.core && MonHistoire.core.auth) {
         MonHistoire.core.auth.afficherUtilisateurDéconnecté();
+        if (MonHistoire.core && MonHistoire.core.navigation) {
+          MonHistoire.core.navigation.showScreen('accueil');
+        }
       }
       if (MonHistoire.features && MonHistoire.features.stories) {
         console.log("[DEBUG] Appel à afficherHistoiresSauvegardees() après déconnexion");

--- a/js/modules/core/navigation.js
+++ b/js/modules/core/navigation.js
@@ -142,12 +142,8 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
       }
     } else {
       // Utilisateur déconnecté
-      // Ne pas rediriger automatiquement vers l'écran de connexion
-      // sauf si l'utilisateur est sur un écran qui nécessite une authentification
-      if (requiresAuth(currentScreen)) {
-        navigateTo(SCREENS.HOME);
-      }
-      
+      navigateTo(SCREENS.HOME);
+
       // Vider l'historique
       screenHistory = [];
     }


### PR DESCRIPTION
## Summary
- ensure logout returns to home screen
- always navigate to home on user sign-out

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851d676d9e0832c9fb4a0dc371feab0