### PR TITLE
Update logout to return promise

### DIFF
--- a/js/core/auth.js
+++ b/js/core/auth.js
@@ -88,8 +88,8 @@ MonHistoire.core.auth = {
       MonHistoire.state.histoiresPartageesListener();
       MonHistoire.state.histoiresPartageesListener = null;
     }
-    
-    firebase.auth().signOut().then(() => {
+
+    return firebase.auth().signOut().then(() => {
       this.logActivite("deconnexion"); // LOG : Déconnexion
       this.afficherUtilisateurDéconnecté();
       this.fermerLogoutModal();
@@ -111,6 +111,12 @@ MonHistoire.core.auth = {
       }
       
       MonHistoire.core.navigation.showScreen("accueil");
+    }).catch(error => {
+      console.error("Erreur lors de la déconnexion:", error);
+      if (MonHistoire.showMessageModal) {
+        MonHistoire.showMessageModal("Erreur lors de la déconnexion. Veuillez réessayer.");
+      }
+      throw error;
     });
   },
   

--- a/js/ui.js
+++ b/js/ui.js
@@ -199,9 +199,13 @@ MonHistoire.ui = {
     });
     
     // Bouton Déconnecter dans la modale de déconnexion
-    document.getElementById("btn-logout")?.addEventListener("click", () => {
+    document.getElementById("btn-logout")?.addEventListener("click", async () => {
       if (MonHistoire.core && MonHistoire.core.auth) {
-        MonHistoire.core.auth.logoutUser();
+        try {
+          await MonHistoire.core.auth.logoutUser();
+        } catch (error) {
+          console.error("Erreur lors de la déconnexion:", error);
+        }
       }
     });
     


### PR DESCRIPTION
## Summary
- return the promise from `logoutUser` and handle errors
- await the logout promise in the UI

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851de1c9210832c9afaeae7f36ee4ad