### PR TITLE
Add feature wrappers

### DIFF
--- a/js/modules/features/cookies.js
+++ b/js/modules/features/cookies.js
@@ -1,0 +1,46 @@
+// js/modules/features/cookies.js
+// Wrapper module delegating to js/features/cookies.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.features = MonHistoire.modules.features || {};
+
+(function() {
+  const getFeature = () => MonHistoire.features && MonHistoire.features.cookies;
+  const apiMethods = [
+    'init',
+    'bindEvents',
+    'afficherBanniereCookies',
+    'masquerBanniereCookies',
+    'accepterTousCookies',
+    'ouvrirParametresCookies',
+    'mettreAJourInterrupteurs',
+    'sauvegarderPreferences',
+    'appliquerPreferences'
+  ];
+
+  const moduleAPI = {};
+  apiMethods.forEach(fn => {
+    moduleAPI[fn] = function(...args) {
+      const feature = getFeature();
+      if (feature && typeof feature[fn] === 'function') {
+        return feature[fn](...args);
+      }
+    };
+  });
+
+  Object.defineProperty(moduleAPI, 'preferences', {
+    get() {
+      const feature = getFeature();
+      return feature ? feature.preferences : undefined;
+    },
+    set(value) {
+      const feature = getFeature();
+      if (feature) {
+        feature.preferences = value;
+      }
+    }
+  });
+
+  MonHistoire.modules.features.cookies = moduleAPI;
+})();

--- a/js/modules/features/export.js
+++ b/js/modules/features/export.js
@@ -1,0 +1,30 @@
+// js/modules/features/export.js
+// Wrapper module delegating to js/features/export.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.features = MonHistoire.modules.features || {};
+
+(function() {
+  const getFeature = () => MonHistoire.features && MonHistoire.features.export;
+  const apiMethods = [
+    'init',
+    'exporterHistoirePDF',
+    'chargerJsPDF',
+    'imgSrcToDataURL',
+    'genererPDF',
+    'genererNomFichier'
+  ];
+
+  const moduleAPI = {};
+  apiMethods.forEach(fn => {
+    moduleAPI[fn] = function(...args) {
+      const feature = getFeature();
+      if (feature && typeof feature[fn] === 'function') {
+        return feature[fn](...args);
+      }
+    };
+  });
+
+  MonHistoire.modules.features.export = moduleAPI;
+})();

--- a/js/modules/messaging/index.js
+++ b/js/modules/messaging/index.js
@@ -1,0 +1,78 @@
+// js/modules/messaging/index.js
+// Entry point wrapper delegating to js/features/messaging
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.messaging = MonHistoire.modules.messaging || {};
+
+(function() {
+  const getFeature = () => MonHistoire.features && MonHistoire.features.messaging;
+  const mod = MonHistoire.modules.messaging;
+
+  mod.init = function(...args) {
+    const f = getFeature();
+    if (f && typeof f.init === 'function') {
+      return f.init(...args);
+    }
+  };
+
+  mod.getOrCreateConversation = function(...args) {
+    const f = getFeature();
+    if (f && typeof f.getOrCreateConversation === 'function') {
+      return f.getOrCreateConversation(...args);
+    }
+    if (mod.storage && mod.storage.getOrCreateConversation) {
+      return mod.storage.getOrCreateConversation(...args);
+    }
+  };
+
+  mod.sendMessage = function(...args) {
+    const f = getFeature();
+    if (f && typeof f.sendMessage === 'function') {
+      return f.sendMessage(...args);
+    }
+    if (mod.storage && mod.storage.sendMessage) {
+      return mod.storage.sendMessage(...args);
+    }
+  };
+
+  mod.listenToMessages = function(...args) {
+    const f = getFeature();
+    if (f && typeof f.listenToMessages === 'function') {
+      return f.listenToMessages(...args);
+    }
+    if (mod.realtime && mod.realtime.listenToMessages) {
+      return mod.realtime.listenToMessages(...args);
+    }
+  };
+
+  mod.markAsRead = function(...args) {
+    const f = getFeature();
+    if (f && typeof f.markAsRead === 'function') {
+      return f.markAsRead(...args);
+    }
+    if (mod.storage && mod.storage.markAsRead) {
+      return mod.storage.markAsRead(...args);
+    }
+  };
+
+  mod.hasUnreadMessages = function(...args) {
+    const f = getFeature();
+    if (f && typeof f.hasUnreadMessages === 'function') {
+      return f.hasUnreadMessages(...args);
+    }
+    if (mod.storage && mod.storage.hasUnreadMessages) {
+      return mod.storage.hasUnreadMessages(...args);
+    }
+  };
+
+  mod.markConversationRead = function(...args) {
+    const f = getFeature();
+    if (f && typeof f.markConversationRead === 'function') {
+      return f.markConversationRead(...args);
+    }
+    if (mod.notifications && mod.notifications.markConversationRead) {
+      return mod.notifications.markConversationRead(...args);
+    }
+  };
+})();

--- a/js/modules/messaging/notifications.js
+++ b/js/modules/messaging/notifications.js
@@ -1,0 +1,27 @@
+// js/modules/messaging/notifications.js
+// Wrapper delegating to js/features/messaging/notifications.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.messaging = MonHistoire.modules.messaging || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.messaging && MonHistoire.features.messaging.notifications;
+  const apiMethods = [
+    'init',
+    'recalculerMessagesNonLus',
+    'mettreAJourBadgeMessages',
+    'mettreAJourBadgeConversations',
+    'markConversationRead'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.messaging.notifications = api;
+})();

--- a/js/modules/messaging/realtime.js
+++ b/js/modules/messaging/realtime.js
@@ -1,0 +1,25 @@
+// js/modules/messaging/realtime.js
+// Wrapper delegating to js/features/messaging/realtime.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.messaging = MonHistoire.modules.messaging || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.messaging && MonHistoire.features.messaging.realtime;
+  const apiMethods = [
+    'init',
+    'listenToMessages',
+    'listenToUnreadMessages'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.messaging.realtime = api;
+})();

--- a/js/modules/messaging/storage.js
+++ b/js/modules/messaging/storage.js
@@ -1,0 +1,28 @@
+// js/modules/messaging/storage.js
+// Wrapper delegating to js/features/messaging/storage.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.messaging = MonHistoire.modules.messaging || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.messaging && MonHistoire.features.messaging.storage;
+  const apiMethods = [
+    'init',
+    'getOrCreateConversation',
+    'sendMessage',
+    'processOfflineMessage',
+    'markAsRead',
+    'hasUnreadMessages'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.messaging.storage = api;
+})();

--- a/js/modules/messaging/ui.js
+++ b/js/modules/messaging/ui.js
@@ -1,0 +1,29 @@
+// js/modules/messaging/ui.js
+// Wrapper delegating to js/features/messaging/ui.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.messaging = MonHistoire.modules.messaging || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.messaging && MonHistoire.features.messaging.ui;
+  const apiMethods = [
+    'init',
+    'openConversationsModal',
+    'closeConversationsModal',
+    'startNewConversation',
+    'openConversation',
+    'closeConversation',
+    'sendCurrentMessage'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.messaging.ui = api;
+})();

--- a/js/modules/sharing/realtime/index.js
+++ b/js/modules/sharing/realtime/index.js
@@ -1,0 +1,28 @@
+// js/modules/sharing/realtime/index.js
+// Wrapper delegating to js/features/sharing/realtime/index.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.sharing = MonHistoire.modules.sharing || {};
+MonHistoire.modules.sharing.realtime = MonHistoire.modules.sharing.realtime || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.sharing && MonHistoire.features.sharing.realtime;
+  const apiMethods = [
+    'init',
+    'configurerEcouteurHistoiresPartagees',
+    'configurerEcouteurNotificationsRealtime',
+    'detacherEcouteursRealtime',
+    'isConnected'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.sharing.realtime = api;
+})();

--- a/js/modules/sharing/realtime/listeners.js
+++ b/js/modules/sharing/realtime/listeners.js
@@ -1,0 +1,28 @@
+// js/modules/sharing/realtime/listeners.js
+// Wrapper delegating to js/features/sharing/realtime/listeners.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.sharing = MonHistoire.modules.sharing || {};
+MonHistoire.modules.sharing.realtime = MonHistoire.modules.sharing.realtime || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.sharing && MonHistoire.features.sharing.realtime && MonHistoire.features.sharing.realtime.listeners;
+  const apiMethods = [
+    'init',
+    'configurerEcouteurHistoiresPartagees',
+    'configurerEcouteurProfilActif',
+    'configurerEcouteursProfilsEnfants',
+    'configurerEcouteurProfilParent'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.sharing.realtime.listeners = api;
+})();

--- a/js/modules/sharing/realtime/notifications.js
+++ b/js/modules/sharing/realtime/notifications.js
@@ -1,0 +1,25 @@
+// js/modules/sharing/realtime/notifications.js
+// Wrapper delegating to js/features/sharing/realtime/notifications.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.sharing = MonHistoire.modules.sharing || {};
+MonHistoire.modules.sharing.realtime = MonHistoire.modules.sharing.realtime || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.sharing && MonHistoire.features.sharing.realtime && MonHistoire.features.sharing.realtime.notifications;
+  const apiMethods = [
+    'init',
+    'configurerEcouteurNotificationsRealtime'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.sharing.realtime.notifications = api;
+})();

--- a/js/modules/sharing/storage.js
+++ b/js/modules/sharing/storage.js
@@ -1,0 +1,26 @@
+// js/modules/sharing/storage.js
+// Wrapper delegating to js/features/sharing/storage.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.sharing = MonHistoire.modules.sharing || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.sharing && MonHistoire.features.sharing.storage;
+  const apiMethods = [
+    'init',
+    'partagerHistoire',
+    'verifierHistoiresPartageesProfilActif',
+    'processOfflinePartage'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.sharing.storage = api;
+})();

--- a/js/modules/sharing/ui.js
+++ b/js/modules/sharing/ui.js
@@ -1,0 +1,27 @@
+// js/modules/sharing/ui.js
+// Wrapper delegating to js/features/sharing/ui.js
+
+window.MonHistoire = window.MonHistoire || {};
+MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.sharing = MonHistoire.modules.sharing || {};
+
+(function() {
+  const feature = () => MonHistoire.features && MonHistoire.features.sharing && MonHistoire.features.sharing.ui;
+  const apiMethods = [
+    'init',
+    'initPartageListeners',
+    'ouvrirModalePartage',
+    'fermerModalePartage',
+    'partagerHistoire'
+  ];
+  const api = {};
+  apiMethods.forEach(fn => {
+    api[fn] = function(...args) {
+      const f = feature();
+      if (f && typeof f[fn] === 'function') {
+        return f[fn](...args);
+      }
+    };
+  });
+  MonHistoire.modules.sharing.ui = api;
+})();


### PR DESCRIPTION
## Summary
- add wrappers for cookies and export in modules/features
- expose messaging modules delegating to feature implementations
- expose sharing realtime, storage and UI modules as wrappers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852cba499d0832c87629734e66c6300