### PR TITLE
Align modular scripts with core

### DIFF
--- a/js/modules/core/navigation.js
+++ b/js/modules/core/navigation.js
@@ -245,6 +245,13 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
    * @param {Object} params - Paramètres supplémentaires (optionnel)
    */
   function showScreen(screen, animate = true, params = {}) {
+    // Arrêter la lecture audio si elle est en cours
+    if (MonHistoire.modules.features &&
+        MonHistoire.modules.features.audio &&
+        typeof MonHistoire.modules.features.audio.stopPlayback === 'function') {
+      MonHistoire.modules.features.audio.stopPlayback();
+    }
+
     // Masquer tous les écrans
     const screens = document.querySelectorAll('.screen');
     screens.forEach(s => {
@@ -283,6 +290,9 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
       if (MonHistoire.screens && MonHistoire.screens[screen] && typeof MonHistoire.screens[screen].init === 'function') {
         MonHistoire.screens[screen].init(params);
       }
+
+      // Gérer certains comportements spécifiques
+      handleSpecialScreenCases(screen);
     } else {
       console.error(`Écran non trouvé: ${screen}`);
     }
@@ -381,6 +391,62 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
       }
     }
   }
+
+  /**
+   * Gère certains cas particuliers lors de l'affichage d'un écran
+   * @param {string} screen - Écran affiché
+   */
+  function handleSpecialScreenCases(screen) {
+    if (screen === SCREENS.STORY_DISPLAY) {
+      const btn = document.getElementById('btn-sauvegarde');
+      if (btn) {
+        if (firebase.auth && firebase.auth().currentUser && MonHistoire.state && MonHistoire.state.resultatSource === 'formulaire') {
+          btn.style.display = 'inline-block';
+        } else {
+          btn.style.display = 'none';
+        }
+      }
+    }
+
+    if (screen === SCREENS.STORY_LIST) {
+      if (MonHistoire.modules.stories && MonHistoire.modules.stories.management &&
+          typeof MonHistoire.modules.stories.management.loadStories === 'function') {
+        MonHistoire.modules.stories.management.loadStories();
+      }
+      const btnAccueil = document.getElementById('btn-accueil-mes-histoires');
+      const group = document.getElementById('mes-histoires-actions');
+      if (btnAccueil && group) {
+        if (previousScreen === SCREENS.STORY_DISPLAY) {
+          btnAccueil.style.display = 'inline-block';
+          group.classList.remove('single');
+        } else {
+          btnAccueil.style.display = 'none';
+          group.classList.add('single');
+        }
+      }
+      marquerHistoiresCommeVues();
+    }
+
+    if (screen === SCREENS.HOME) {
+      const footer = document.querySelector('footer');
+      if (footer) {
+        if (MonHistoire.state && MonHistoire.state.profilActif && MonHistoire.state.profilActif.type === 'enfant') {
+          footer.style.display = 'none';
+        } else {
+          footer.style.display = 'block';
+        }
+      }
+    } else {
+      const footer = document.querySelector('footer');
+      if (footer) {
+        footer.style.display = 'none';
+      }
+    }
+
+    if (MonHistoire.events) {
+      MonHistoire.events.emit('screenChanged', { screen, previousScreen });
+    }
+  }
   
   /**
    * Vérifie si l'écran nécessite une authentification
@@ -449,12 +515,77 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
     if (canGoBack()) {
       // Récupérer l'écran précédent
       const prevScreen = screenHistory.pop() || SCREENS.HOME;
-      
+
       // Naviguer vers l'écran précédent
       window.history.back();
-      
+
       // Mettre à jour l'écran courant
       currentScreen = prevScreen;
+    }
+  }
+
+  /**
+   * Retourne depuis l'écran de résultat vers la page appropriée
+   */
+  function retourDepuisResultat() {
+    if (MonHistoire.state && MonHistoire.state.resultatSource === 'mes-histoires') {
+      navigateTo(SCREENS.STORY_LIST);
+    } else {
+      navigateTo(SCREENS.STORY_CREATION);
+    }
+  }
+
+  /**
+   * Marque toutes les histoires comme vues pour le profil actif
+   */
+  function marquerHistoiresCommeVues() {
+    try {
+      const user = firebase.auth && firebase.auth().currentUser;
+      if (!user) return;
+
+      if (!MonHistoire.state || !MonHistoire.state.profilActif) {
+        MonHistoire.state = MonHistoire.state || {};
+        MonHistoire.state.profilActif = localStorage.getItem('profilActif') ? JSON.parse(localStorage.getItem('profilActif')) : { type: 'parent' };
+      }
+
+      const profilId = MonHistoire.state.profilActif.type === 'parent' ? 'parent' : MonHistoire.state.profilActif.id;
+
+      let storiesRef;
+      if (MonHistoire.state.profilActif.type === 'parent') {
+        storiesRef = firebase.firestore()
+          .collection('users')
+          .doc(user.uid)
+          .collection('stories')
+          .where('nouvelleHistoire', '==', true);
+      } else {
+        storiesRef = firebase.firestore()
+          .collection('users')
+          .doc(user.uid)
+          .collection('profils_enfant')
+          .doc(MonHistoire.state.profilActif.id)
+          .collection('stories')
+          .where('nouvelleHistoire', '==', true);
+      }
+
+      storiesRef.get().then(snapshot => {
+        if (snapshot.empty) return;
+        const batch = firebase.firestore().batch();
+        snapshot.forEach(doc => {
+          batch.update(doc.ref, {
+            nouvelleHistoire: false,
+            vueLe: firebase.firestore.FieldValue.serverTimestamp()
+          });
+        });
+        return batch.commit();
+      }).then(() => {
+        if (MonHistoire.modules.sharing && MonHistoire.modules.sharing.notificationsNonLues) {
+          MonHistoire.modules.sharing.notificationsNonLues[profilId] = 0;
+        }
+      }).catch(err => {
+        console.error('Erreur lors du marquage des histoires comme vues:', err);
+      });
+    } catch (err) {
+      console.error('Erreur lors du marquage des histoires comme vues:', err);
     }
   }
   
@@ -496,6 +627,8 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
     navigateTo: navigateTo,
     showScreen: showScreen,
     goBack: goBack,
+    retourDepuisResultat: retourDepuisResultat,
+    marquerHistoiresCommeVues: marquerHistoiresCommeVues,
     getCurrentScreen: getCurrentScreen,
     getPreviousScreen: getPreviousScreen,
     getScreens: getScreens,

--- a/js/modules/stories/generator.js
+++ b/js/modules/stories/generator.js
@@ -443,7 +443,11 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
         return;
       }
     }
-    
+
+    // Indiquer la provenance du résultat
+    MonHistoire.state = MonHistoire.state || {};
+    MonHistoire.state.resultatSource = 'formulaire';
+
     // Éviter les générations multiples
     if (isGenerating) {
       return;
@@ -480,7 +484,22 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
         if (MonHistoire.events) {
           MonHistoire.events.emit('storyGenerated', story);
         }
-        
+
+        // Vérifier si l'utilisateur approche de son quota d'histoires
+        if (firebase.auth && firebase.auth().currentUser &&
+            MonHistoire.modules.core &&
+            MonHistoire.modules.core.storage &&
+            typeof MonHistoire.modules.core.storage.verifierSeuilAlerteHistoires === 'function') {
+          MonHistoire.modules.core.storage.verifierSeuilAlerteHistoires()
+            .then(seuilAtteint => {
+              if (seuilAtteint) {
+                setTimeout(() => {
+                  MonHistoire.showMessageModal(`Attention : tu approches de la limite de ${MonHistoire.config.MAX_HISTOIRES} histoires sauvegardées.`);
+                }, 1000);
+              }
+            });
+        }
+
         isGenerating = false;
         console.log("Histoire générée");
       })


### PR DESCRIPTION
## Summary
- add quota utilities to `modules/core/storage`
- integrate quota warnings in `modules/stories/generator`
- sync navigation module with core behaviours

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6852cba9b5b8832cafef299331a51346