### PR TITLE
Add missing module warnings

### DIFF
--- a/js/adapters/features-adapter.js
+++ b/js/adapters/features-adapter.js
@@ -37,6 +37,8 @@
     };
     
     console.log("[Adapter] Adaptateur audio initialisé avec succès");
+  } else {
+    console.warn("[Adapter] Module audio manquant dans MonHistoire.modules.features");
   }
   
   // Adapter pour le module cookies
@@ -84,6 +86,8 @@
     };
     
     console.log("[Adapter] Adaptateur cookies initialisé avec succès");
+  } else {
+    console.warn("[Adapter] Module cookies manquant dans MonHistoire.modules.core");
   }
   
   // Adapter pour le module export
@@ -121,6 +125,8 @@
     };
     
     console.log("[Adapter] Adaptateur export initialisé avec succès");
+  } else {
+    console.warn("[Adapter] Module export manquant dans MonHistoire.modules.stories");
   }
   
   // Adapter pour le module sharing
@@ -154,6 +160,8 @@
     MonHistoire.features.sharing.realtime = MonHistoire.modules.sharing.realtime || {};
     
     console.log("[Adapter] Adaptateur sharing initialisé avec succès");
+  } else {
+    console.warn("[Adapter] Module sharing manquant dans MonHistoire.modules");
   }
   
   console.log("[Adapter] Adaptateur de fonctionnalités initialisé avec succès");

--- a/js/adapters/stories-adapter.js
+++ b/js/adapters/stories-adapter.js
@@ -126,6 +126,8 @@
     };
     
     console.log("[Adapter] Adaptateur d'affichage d'histoires initialisé avec succès");
+  } else {
+    console.warn("[Adapter] Module stories.display manquant dans MonHistoire.modules.stories");
   }
   
   // Adapter pour le module de gestion
@@ -178,6 +180,8 @@
     };
     
     console.log("[Adapter] Adaptateur de gestion d'histoires initialisé avec succès");
+  } else {
+    console.warn("[Adapter] Module stories.management manquant dans MonHistoire.modules.stories");
   }
   
   // Adapter pour le module de génération
@@ -200,6 +204,8 @@
     };
     
     console.log("[Adapter] Adaptateur de génération d'histoires initialisé avec succès");
+  } else {
+    console.warn("[Adapter] Module stories.generator manquant dans MonHistoire.modules.stories");
   }
   
   console.log("[Adapter] Adaptateur d'histoires initialisé avec succès");

--- a/js/adapters/ui-adapter.js
+++ b/js/adapters/ui-adapter.js
@@ -7,7 +7,10 @@
   // Vérifier que les namespaces nécessaires existent
   window.MonHistoire = window.MonHistoire || {};
   MonHistoire.modules = MonHistoire.modules || {};
-  MonHistoire.modules.app = MonHistoire.modules.app || {};
+  if (!MonHistoire.modules.app) {
+    MonHistoire.modules.app = {};
+    console.warn("[Adapter] Module app manquant dans MonHistoire.modules");
+  }
   
   // Implémentation de la fonction closeMessageModal
   function closeMessageModalImpl() {


### PR DESCRIPTION
## Summary
- warn if target modules are missing in features-adapter
- warn if target modules are missing in stories-adapter
- warn if app module is absent in ui-adapter

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(fails: package not found due to offline env)*

------
https://chatgpt.com/codex/tasks/task_e_6852cbae96dc832c94941c93ff0bde94