### PR TITLE
Refactor cookies feature module

### DIFF
--- a/js/modules/features/cookies.js
+++ b/js/modules/features/cookies.js
@@ -1,46 +1,9 @@
 // js/modules/features/cookies.js
-// Wrapper module delegating to js/features/cookies.js
+// Re-export core cookies module for backward compatibility
 
 window.MonHistoire = window.MonHistoire || {};
 MonHistoire.modules = MonHistoire.modules || {};
+MonHistoire.modules.core = MonHistoire.modules.core || {};
 MonHistoire.modules.features = MonHistoire.modules.features || {};
 
-(function() {
-  const getFeature = () => MonHistoire.features && MonHistoire.features.cookies;
-  const apiMethods = [
-    'init',
-    'bindEvents',
-    'afficherBanniereCookies',
-    'masquerBanniereCookies',
-    'accepterTousCookies',
-    'ouvrirParametresCookies',
-    'mettreAJourInterrupteurs',
-    'sauvegarderPreferences',
-    'appliquerPreferences'
-  ];
-
-  const moduleAPI = {};
-  apiMethods.forEach(fn => {
-    moduleAPI[fn] = function(...args) {
-      const feature = getFeature();
-      if (feature && typeof feature[fn] === 'function') {
-        return feature[fn](...args);
-      }
-    };
-  });
-
-  Object.defineProperty(moduleAPI, 'preferences', {
-    get() {
-      const feature = getFeature();
-      return feature ? feature.preferences : undefined;
-    },
-    set(value) {
-      const feature = getFeature();
-      if (feature) {
-        feature.preferences = value;
-      }
-    }
-  });
-
-  MonHistoire.modules.features.cookies = moduleAPI;
-})();
+MonHistoire.modules.features.cookies = MonHistoire.modules.core.cookies;


### PR DESCRIPTION
## Summary
- remove old delegation logic from cookies feature
- expose the core cookies API directly for backward compatibility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852eef1bccc832c8b4726a186a73264