### PR TITLE
Fix module fallbacks

### DIFF
--- a/js/modules/features/export.js
+++ b/js/modules/features/export.js
@@ -252,8 +252,10 @@ MonHistoire.modules.features.export = {
     doc.save(nomFichier);
     
     // Log l'activité
-    if (MonHistoire.core && MonHistoire.core.auth && firebase.auth().currentUser) {
-      MonHistoire.core.auth.logActivite("export_pdf", { 
+    if (MonHistoire.modules.user &&
+        MonHistoire.modules.user.auth &&
+        firebase.auth().currentUser) {
+      MonHistoire.modules.user.auth.logActivity("export_pdf", {
         histoire_id: histoire.id,
         titre: histoire.titre
       });

--- a/js/modules/sharing/notifications.js
+++ b/js/modules/sharing/notifications.js
@@ -533,8 +533,8 @@ MonHistoire.modules.sharing.notifications = {
     this.fermerNotificationPartage();
     
     // Redirige vers "Mes histoires"
-    if (MonHistoire.core && MonHistoire.core.navigation) {
-      MonHistoire.core.navigation.showScreen("mes-histoires");
+    if (MonHistoire.modules.core && MonHistoire.modules.core.navigation) {
+      MonHistoire.modules.core.navigation.showScreen("mes-histoires");
     }
   },
   

--- a/js/modules/sharing/storage.js
+++ b/js/modules/sharing/storage.js
@@ -146,8 +146,8 @@ MonHistoire.modules.sharing.storage = {
       }
 
       // Log de l'activité
-      if (MonHistoire.core && MonHistoire.core.auth) {
-        MonHistoire.core.auth.logActivite("partage_histoire", { 
+      if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
+        MonHistoire.modules.user.auth.logActivity("partage_histoire", {
           destinataire_type: type,
           destinataire_id: id,
           destinataire_prenom: prenom
@@ -327,8 +327,8 @@ MonHistoire.modules.sharing.storage = {
       }
 
       // Log de l'activité
-      if (MonHistoire.core && MonHistoire.core.auth) {
-        MonHistoire.core.auth.logActivite("partage_histoire_offline", { 
+      if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
+        MonHistoire.modules.user.auth.logActivity("partage_histoire_offline", {
           destinataire_type: type,
           destinataire_id: id,
           destinataire_prenom: prenom

--- a/js/modules/stories/generator.js
+++ b/js/modules/stories/generator.js
@@ -936,8 +936,6 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
       // Affiche l'écran de résultat
       if (MonHistoire.modules.core && MonHistoire.modules.core.navigation) {
         MonHistoire.modules.core.navigation.showScreen("resultat");
-      } else if (MonHistoire.core && MonHistoire.core.navigation) {
-        MonHistoire.core.navigation.showScreen("resultat");
       }
       
       // Prépare les données pour l'API

--- a/js/modules/ui/common.js
+++ b/js/modules/ui/common.js
@@ -265,9 +265,6 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
       console.log("[DEBUG] Clic sur le bouton d'inscription (Créer un compte)");
       if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
         MonHistoire.modules.user.auth.toggleSignup(true);
-      } else if (MonHistoire.core && MonHistoire.core.auth) {
-        // Fallback vers l'ancien namespace
-        MonHistoire.core.auth.toggleSignup(true);
       } else {
         console.error("[ERROR] Module auth non disponible pour l'inscription");
       }
@@ -282,10 +279,6 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
         if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
           console.log("[DEBUG] Utilisation de MonHistoire.modules.user.auth.toggleSignup");
           MonHistoire.modules.user.auth.toggleSignup(false);
-        } else if (MonHistoire.core && MonHistoire.core.auth) {
-          // Fallback vers l'ancien namespace
-          console.log("[DEBUG] Utilisation de MonHistoire.core.auth.toggleSignup (fallback)");
-          MonHistoire.core.auth.toggleSignup(false);
         } else {
           console.error("[ERROR] Aucun module auth disponible pour toggleSignup");
         }
@@ -304,10 +297,6 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
         if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
           console.log("[DEBUG] Utilisation de MonHistoire.modules.user.auth.toggleReset");
           MonHistoire.modules.user.auth.toggleReset(true);
-        } else if (MonHistoire.core && MonHistoire.core.auth) {
-          // Fallback vers l'ancien namespace
-          console.log("[DEBUG] Utilisation de MonHistoire.core.auth.toggleReset (fallback)");
-          MonHistoire.core.auth.toggleReset(true);
         } else {
           console.error("[ERROR] Aucun module auth disponible pour toggleReset");
         }
@@ -325,10 +314,6 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
         if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
           console.log("[DEBUG] Utilisation de MonHistoire.modules.user.auth.toggleReset");
           MonHistoire.modules.user.auth.toggleReset(false);
-        } else if (MonHistoire.core && MonHistoire.core.auth) {
-          // Fallback vers l'ancien namespace
-          console.log("[DEBUG] Utilisation de MonHistoire.core.auth.toggleReset (fallback)");
-          MonHistoire.core.auth.toggleReset(false);
         } else {
           console.error("[ERROR] Aucun module auth disponible pour toggleReset");
         }
@@ -347,10 +332,6 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
         if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
           console.log("[DEBUG] Utilisation de MonHistoire.modules.user.auth.sendReset");
           MonHistoire.modules.user.auth.sendReset();
-        } else if (MonHistoire.core && MonHistoire.core.auth) {
-          // Fallback vers l'ancien namespace
-          console.log("[DEBUG] Utilisation de MonHistoire.core.auth.sendReset (fallback)");
-          MonHistoire.core.auth.sendReset();
         } else {
           console.error("[ERROR] Aucun module auth disponible pour sendReset");
         }

--- a/js/modules/ui/modals.js
+++ b/js/modules/ui/modals.js
@@ -43,8 +43,8 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
       .then(() => {
         annulerAjoutEnfant();
         afficherProfilsEnfants();
-        if (MonHistoire.core && MonHistoire.core.auth) {
-          MonHistoire.core.auth.logActivite('creation_profil_enfant', { prenom });
+        if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
+          MonHistoire.modules.user.auth.logActivity('creation_profil_enfant', { prenom });
         }
       })
       .catch(error => {
@@ -146,11 +146,16 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
     const user = firebase.auth().currentUser;
     if (!user) return;
     if (!MonHistoire.state.profilsEnfantModifies || MonHistoire.state.profilsEnfantModifies.length === 0) {
-      if (continueWithParentProfile && MonHistoire.core && MonHistoire.core.auth) {
+      if (continueWithParentProfile &&
+          MonHistoire.modules.user &&
+          MonHistoire.modules.user.account &&
+          typeof MonHistoire.modules.user.account.fermerMonCompte === 'function') {
         return;
       }
-      if (MonHistoire.core && MonHistoire.core.auth) {
-        MonHistoire.core.auth.fermerMonCompte();
+      if (MonHistoire.modules.user &&
+          MonHistoire.modules.user.account &&
+          typeof MonHistoire.modules.user.account.fermerMonCompte === 'function') {
+        MonHistoire.modules.user.account.fermerMonCompte();
       }
       return;
     }
@@ -188,14 +193,14 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
             return Promise.all(deletes);
           })
         );
-        if (MonHistoire.core && MonHistoire.core.auth) {
-          MonHistoire.core.auth.logActivite('suppression_profil_enfant', { id_enfant: modif.id });
+        if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
+          MonHistoire.modules.user.auth.logActivity('suppression_profil_enfant', { id_enfant: modif.id });
         }
       }
       if (modif.action === 'modifier') {
         batch.update(ref.doc(modif.id), { prenom: modif.nouveauPrenom });
-        if (MonHistoire.core && MonHistoire.core.auth) {
-          MonHistoire.core.auth.logActivite('modification_prenom_profil', { id_enfant: modif.id });
+        if (MonHistoire.modules.user && MonHistoire.modules.user.auth) {
+          MonHistoire.modules.user.auth.logActivity('modification_prenom_profil', { id_enfant: modif.id });
         }
       }
       if (modif.action === 'messagerie') {
@@ -218,14 +223,18 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
         setTimeout(() => {
           form.style.display = 'none';
           form.classList.remove('fade-out');
-          if (MonHistoire.core && MonHistoire.core.auth) {
-            MonHistoire.core.auth.fermerMonCompte();
+          if (MonHistoire.modules.user &&
+              MonHistoire.modules.user.account &&
+              typeof MonHistoire.modules.user.account.fermerMonCompte === 'function') {
+            MonHistoire.modules.user.account.fermerMonCompte();
           }
           setTimeout(() => { MonHistoire.showMessageModal('Modifications enregistrées !'); }, 100);
         }, 250);
       } else {
-        if (MonHistoire.core && MonHistoire.core.auth) {
-          MonHistoire.core.auth.fermerMonCompte();
+        if (MonHistoire.modules.user &&
+            MonHistoire.modules.user.account &&
+            typeof MonHistoire.modules.user.account.fermerMonCompte === 'function') {
+          MonHistoire.modules.user.account.fermerMonCompte();
         }
         setTimeout(() => { MonHistoire.showMessageModal('Modifications enregistrées !'); }, 100);
       }

--- a/js/modules/user/auth.js
+++ b/js/modules/user/auth.js
@@ -506,6 +506,16 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
   }
 
   /**
+   * Ferme la modale de déconnexion/changement de profil
+   */
+  function fermerLogoutModal() {
+    const modal = document.getElementById('logout-modal');
+    if (modal) {
+      modal.classList.remove('show');
+    }
+  }
+
+  /**
    * Fonction de connexion utilisateur qui récupère les valeurs du formulaire
    * et gère toutes les actions post-connexion
    */
@@ -680,8 +690,10 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
         afficherUtilisateurDéconnecté();
         
         // Fermer la modale de déconnexion
-        if (MonHistoire.core && MonHistoire.core.auth) {
-          MonHistoire.core.auth.fermerLogoutModal();
+        if (MonHistoire.modules.user &&
+            MonHistoire.modules.user.auth &&
+            typeof MonHistoire.modules.user.auth.fermerLogoutModal === 'function') {
+          MonHistoire.modules.user.auth.fermerLogoutModal();
         }
         
         // Réinitialiser le profil actif
@@ -762,6 +774,7 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
     loginUser: loginUser,
     registerUser: registerUser,
     logoutUser: logoutUser,
-    logActivity: logActivity
+    logActivity: logActivity,
+    fermerLogoutModal: fermerLogoutModal
   };
 })();


### PR DESCRIPTION
## Summary
- use `MonHistoire.modules` instead of legacy `MonHistoire.core`
- close logout modal from modular auth module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853111d8f34832cbb023de60109fd11