### PR TITLE
Fix script order for event availability

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
   <!-- Initialisation Firebase -->
   <script src="js/firebase-init.js"></script>
 
+  <!-- Initialisation de l'application -->
+  <script src="js/app.js" defer></script>
+  <script src="js/common.js" defer></script>
+
   <!-- Modules core -->
   <script src="js/modules/core/config.js" defer></script>
   <script src="js/modules/core/cookies.js" defer></script>


### PR DESCRIPTION
## Summary
- load `js/app.js` and `js/common.js` right after Firebase init so modules can use `MonHistoire.events`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531d4ce8f0832c812d9ca7cc2c6f5d