### PR TITLE
Remove redundant Firebase init call

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -374,12 +374,12 @@ MonHistoire.init = function() {
   console.log("[DEBUG] Initialisation de l'application MonHistoire");
   
   // Initialiser Firebase
-  console.log("[DEBUG] Initialisation de Firebase");
-  if (this.config && typeof this.config.initFirebase === 'function') {
-    this.config.initFirebase();
-  } else {
-    console.warn("initFirebase() non disponible - Firebase déjà initialisé ?");
-  }
+  // console.log("[DEBUG] Initialisation de Firebase");
+  // if (this.config && typeof this.config.initFirebase === 'function') {
+  //   this.config.initFirebase();
+  // } else {
+  //   console.warn("initFirebase() non disponible - Firebase déjà initialisé ?");
+  // }
   
   // Configurer les écouteurs d'état de connexion
   window.addEventListener('online', () => {


### PR DESCRIPTION
## Summary
- stop calling `this.config.initFirebase()` in the main app initialization

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532875b564832c99b6f2ce11d80b7a