### PR TITLE
Fix initFirebase call in app initialization

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -374,12 +374,17 @@ MonHistoire.init = function() {
   console.log("[DEBUG] Initialisation de l'application MonHistoire");
   
   // Initialiser Firebase
-  // console.log("[DEBUG] Initialisation de Firebase");
-  // if (this.config && typeof this.config.initFirebase === 'function') {
-  //   this.config.initFirebase();
-  // } else {
-  //   console.warn("initFirebase() non disponible - Firebase déjà initialisé ?");
-  // }
+  console.log("[DEBUG] Initialisation de Firebase");
+  if (
+    MonHistoire.config &&
+    typeof MonHistoire.config.initFirebase === "function"
+  ) {
+    MonHistoire.config.initFirebase();
+  } else {
+    console.warn(
+      "initFirebase() non disponible - Firebase déjà initialisé ?"
+    );
+  }
   
   // Configurer les écouteurs d'état de connexion
   window.addEventListener('online', () => {


### PR DESCRIPTION
## Summary
- ensure Firebase initialization is called only when available

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532f9f2df8832c9eb9f93162dfb35c