### PR TITLE
Fix initFirebase merging in config

### DIFF
--- a/js/modules/core/config.js
+++ b/js/modules/core/config.js
@@ -103,8 +103,19 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
   };
 
   // Fusionner avec une configuration globale existante si nécessaire
+  let existingInitFirebase;
   if (window.MonHistoire.config) {
+    // Conserver la référence à initFirebase si elle existe
+    if (typeof window.MonHistoire.config.initFirebase === 'function') {
+      existingInitFirebase = window.MonHistoire.config.initFirebase;
+    }
+
     config = deepMerge(window.MonHistoire.config, config);
+  }
+
+  // Réattacher initFirebase après la fusion si nécessaire
+  if (existingInitFirebase) {
+    config.initFirebase = existingInitFirebase;
   }
 
   // Exposer la configuration globalement pour compatibilité avec l'ancien code


### PR DESCRIPTION
## Summary
- preserve any existing `initFirebase` when merging config

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853364ce198832c94e117fd83f50303