### PR TITLE
Add basic Jest test for core config

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,9 +521,9 @@ MonHistoire.debug("Message de débogage", data);
 
 ## Tests
 
-Avant d'exécuter `npm test`, lancez d'abord `npm install` pour installer Jest et les autres dépendances de développement.
+Avant d'exécuter `npm test`, installez d'abord les dépendances de développement avec `npm install`.
 
-Si vous travaillez sans connexion Internet, préparez un cache npm ou un dossier `node_modules` sur une machine connectée, puis exécutez le script `offline-setup.sh` pour installer ces dépendances en mode hors ligne.
+Si vous travaillez sans connexion Internet, copiez un dossier `node_modules` préalablement préparé ou un cache npm dans `./npm-cache` puis lancez `./offline-setup.sh` pour installer ces dépendances hors ligne.
 
 ```bash
 npm test

--- a/tests/config-core.test.js
+++ b/tests/config-core.test.js
@@ -1,0 +1,28 @@
+const { JSDOM } = require('jsdom');
+
+describe('core config module', () => {
+  let initFirebaseMock;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('', { url: 'http://localhost' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.MonHistoire = { config: { initFirebase: jest.fn() }, modules: { core: {} } };
+    global.console = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    initFirebaseMock = global.MonHistoire.config.initFirebase;
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.MonHistoire;
+    delete global.console;
+  });
+
+  test('initFirebase remains defined after loading core config', () => {
+    require('../js/modules/core/config.js');
+    expect(typeof window.MonHistoire.config.initFirebase).toBe('function');
+    expect(window.MonHistoire.config.initFirebase).toBe(initFirebaseMock);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test ensuring `MonHistoire.config.initFirebase` persists
- clarify offline test instructions in README

## Testing
- `bash offline-setup.sh` *(fails: cache directory not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853396645d8832cbefc21a466f4b790