### PR TITLE
Initialize core config before app

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,13 @@
 
   <script src="js/config.js" defer></script>
 
+  <!-- Modules core -->
+  <script src="js/modules/core/config.js" defer></script>
+
   <!-- Initialisation de l'application -->
   <script src="js/app.js" defer></script>
   <script src="js/common.js" defer></script>
 
-  <!-- Modules core -->
-  <script src="js/modules/core/config.js" defer></script>
   <script src="js/modules/core/cookies.js" defer></script>
   <script src="js/modules/core/navigation.js" defer></script>
   <script src="js/modules/core/storage.js" defer></script>

--- a/js/app.js
+++ b/js/app.js
@@ -669,8 +669,17 @@ document.addEventListener('DOMContentLoaded', function() {
   
   // Vérifier l'état de connexion initial
   MonHistoire.state.isConnected = navigator.onLine;
-  
+
   // Initialiser l'application
+  if (
+    MonHistoire.modules &&
+    MonHistoire.modules.core &&
+    MonHistoire.modules.core.config &&
+    typeof MonHistoire.modules.core.config.init === 'function'
+  ) {
+    MonHistoire.modules.core.config.init();
+  }
+
   MonHistoire.init();
   
   // Gérer la visibilité du footer en fonction du profil actif


### PR DESCRIPTION
## Summary
- load the core config module before `app.js`
- call `MonHistoire.modules.core.config.init()` before `MonHistoire.init()`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533c66b310832ca187cbf0b2460546