### PR TITLE
Initialize config module on DOM load

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -669,7 +669,17 @@ document.addEventListener('DOMContentLoaded', function() {
   
   // Vérifier l'état de connexion initial
   MonHistoire.state.isConnected = navigator.onLine;
-  
+
+  // Initialiser la configuration si disponible
+  if (
+    MonHistoire.modules &&
+    MonHistoire.modules.core &&
+    MonHistoire.modules.core.config &&
+    typeof MonHistoire.modules.core.config.init === 'function'
+  ) {
+    MonHistoire.modules.core.config.init();
+  }
+
   // Initialiser l'application
   MonHistoire.init();
   


### PR DESCRIPTION
## Summary
- ensure core config module initializes before app startup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533c6c1448832c836d88958eb6e72d