### PR TITLE
Add global RGPD tab switcher

### DIFF
--- a/js/modules/core/cookies.js
+++ b/js/modules/core/cookies.js
@@ -491,6 +491,40 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
     
     console.log("Préférences de cookies réinitialisées");
   }
+
+  /**
+   * Change d'onglet dans la modale RGPD
+   * Repris depuis js/features/cookies.js
+   * @param {Event} event - Événement de clic
+   * @param {string} tabId - ID de l'onglet à afficher
+   */
+  function switchRgpdTab(event, tabId) {
+    // Masque tous les onglets
+    const tabPanes = document.getElementsByClassName('rgpd-tab-pane');
+    for (let i = 0; i < tabPanes.length; i++) {
+      tabPanes[i].classList.remove('active');
+    }
+
+    // Désactive tous les boutons d'onglet
+    const tabButtons = document.getElementsByClassName('rgpd-tab-button');
+    for (let i = 0; i < tabButtons.length; i++) {
+      tabButtons[i].classList.remove('active');
+    }
+
+    // Affiche l'onglet sélectionné
+    const pane = document.getElementById(tabId);
+    if (pane) {
+      pane.classList.add('active');
+    }
+
+    // Active le bouton d'onglet sélectionné
+    if (event && event.currentTarget) {
+      event.currentTarget.classList.add('active');
+    }
+  }
+
+  // Expose la fonction globalement pour l'utilisation dans l'attribut onclick
+  window.switchRgpdTab = switchRgpdTab;
   
   // API publique
   MonHistoire.modules.core.cookies = {


### PR DESCRIPTION
## Summary
- implement `switchRgpdTab` in core cookies module
- expose it globally so the RGPD modal tabs can work

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c661263c832ca3835f6001ca2b01