### PR TITLE
Add missing UI events loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,8 @@
   <script src="js/modules/ui/common.js" defer></script>
   <script src="js/modules/ui/whitebar-fix.js" defer></script>
   <script src="js/modules/ui/debug.js" defer></script>
+  <script src="js/modules/ui/modals.js" defer></script>
+  <script src="js/modules/ui/events.js" defer></script>
 
   <!-- Module principal de l'application -->
   <script src="js/modules/app.js" defer></script>


### PR DESCRIPTION
## Summary
- load modals.js and events.js modules in `index.html`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `./offline-setup.sh` *(fails: cache directory not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ce6b5fb8832cab802929a2115929