### PR TITLE
Check auth before login

### DIFF
--- a/js/modules/user/auth.js
+++ b/js/modules/user/auth.js
@@ -133,7 +133,19 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
         reject(new Error("E-mail et mot de passe requis"));
         return;
       }
-      
+
+      // S'assurer que Firebase Auth est disponible
+      if (!auth) {
+        init();
+      }
+
+      // Après tentative d'initialisation, si "auth" est toujours indisponible
+      // on signale explicitement l'erreur à l'appelant
+      if (!auth) {
+        reject(new Error("Service d’authentification non disponible"));
+        return;
+      }
+
       // Connecter l'utilisateur
       auth.signInWithEmailAndPassword(email, password)
         .then(userCredential => {


### PR DESCRIPTION
## Summary
- handle missing auth initialization in user login

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ea2408a4832ca9b259e760843425