### PR TITLE
Add public delete wrapper and saved story display

### DIFF
--- a/js/modules/stories/display.js
+++ b/js/modules/stories/display.js
@@ -226,6 +226,43 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
       }
     }
   }
+
+  /**
+   * Charge et affiche une histoire sauvegardée
+   * @param {string} id - ID de l'histoire
+   */
+  function afficherHistoireSauvegardee(id) {
+    if (!id) {
+      return;
+    }
+
+    MonHistoire.state = MonHistoire.state || {};
+    MonHistoire.state.resultatSource = 'mes-histoires';
+
+    if (MonHistoire.modules.core && MonHistoire.modules.core.storage) {
+      MonHistoire.modules.core.storage.getStory(id)
+        .then(story => {
+          if (!story) {
+            if (MonHistoire.showMessageModal) {
+              MonHistoire.showMessageModal("Histoire non trouvée.");
+            }
+            return;
+          }
+
+          showStory(story);
+
+          if (MonHistoire.modules.core && MonHistoire.modules.core.navigation) {
+            MonHistoire.modules.core.navigation.showScreen('resultat');
+          }
+        })
+        .catch(error => {
+          console.error("Erreur lors de la récupération de l'histoire:", error);
+          if (MonHistoire.showMessageModal) {
+            MonHistoire.showMessageModal("Erreur lors de la récupération de l'histoire.");
+          }
+        });
+    }
+  }
   
   /**
    * Obtient l'histoire actuellement affichée
@@ -256,6 +293,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
   MonHistoire.modules.stories.display = {
     init: init,
     showStory: showStory,
+    afficherHistoireSauvegardee: afficherHistoireSauvegardee,
     getCurrentStory: getCurrentStory,
     formatStory: formatStory
   };

--- a/js/modules/stories/management.js
+++ b/js/modules/stories/management.js
@@ -601,6 +601,20 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
   function getStoryById(storyId) {
     return stories.find(s => s.id === storyId) || null;
   }
+
+  /**
+   * Wrapper public pour supprimer une histoire avec confirmation
+   * @param {string} id - ID de l'histoire à supprimer
+   */
+  function supprimerHistoire(id) {
+    if (!id) {
+      return;
+    }
+
+    // Réutilise la logique existante de confirmation/suppression
+    showDeleteConfirmation(id);
+    // L'utilisateur devra confirmer via le modal qui déclenchera handleDeleteStory
+  }
   
   // API publique
   MonHistoire.modules.stories.management = {
@@ -608,6 +622,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
     loadStories: loadStories,
     saveStory: saveStory,
     getStories: getStories,
-    getStoryById: getStoryById
+    getStoryById: getStoryById,
+    supprimerHistoire: supprimerHistoire
   };
 })();


### PR DESCRIPTION
## Summary
- expose new `supprimerHistoire` wrapper in management module
- allow displaying a saved story by id from the display module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ee1987a8832ca3078556d94a8f3d