### PR TITLE
Fix PDF export namespace calls

### DIFF
--- a/js/modules/ui/common.js
+++ b/js/modules/ui/common.js
@@ -301,8 +301,8 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
     
     // Bouton Export PDF (protégé contre les clics multiples)
     protegerBouton("btn-export-pdf", () => {
-      if (MonHistoire.modules.stories && MonHistoire.modules.stories.export) {
-        MonHistoire.modules.stories.export.exporterHistoirePDF();
+      if (MonHistoire.modules.features && MonHistoire.modules.features.export) {
+        MonHistoire.modules.features.export.exporterHistoirePDF();
       }
     });
     

--- a/js/modules/ui/events.js
+++ b/js/modules/ui/events.js
@@ -125,8 +125,8 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
     });
 
     protegerBouton('btn-export-pdf', () => {
-      if (MonHistoire.modules.stories && MonHistoire.modules.stories.export) {
-        MonHistoire.modules.stories.export.exporterHistoirePDF();
+      if (MonHistoire.modules.features && MonHistoire.modules.features.export) {
+        MonHistoire.modules.features.export.exporterHistoirePDF();
       }
     });
 


### PR DESCRIPTION
## Summary
- use `modules.features.export` instead of `modules.stories.export` when exporting PDFs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ee1e34cc832caf4a923817bcbc79