### PR TITLE
Add fallback for legacy story getter

### DIFF
--- a/js/modules/features/export.js
+++ b/js/modules/features/export.js
@@ -80,9 +80,19 @@ MonHistoire.modules.features.export = {
   // Génère le PDF avec l'histoire
   async genererPDF() {
     // Récupère l'histoire affichée
-    const histoire =
+    let histoire =
       MonHistoire.modules.stories.display.getCurrentStory &&
       MonHistoire.modules.stories.display.getCurrentStory();
+
+    // Fallback vers l'ancien namespace si aucune histoire n'est trouvée
+    if (histoire === null &&
+        MonHistoire.features &&
+        MonHistoire.features.stories &&
+        MonHistoire.features.stories.display &&
+        typeof MonHistoire.features.stories.display.getHistoireAffichee === "function") {
+      console.warn("[Export] Utilisation du fallback getHistoireAffichee depuis MonHistoire.features");
+      histoire = MonHistoire.features.stories.display.getHistoireAffichee();
+    }
     
     // Crée un nouveau document PDF
     const { jsPDF } = window.jspdf;

--- a/js/modules/sharing/ui.js
+++ b/js/modules/sharing/ui.js
@@ -34,7 +34,17 @@ MonHistoire.modules.sharing.ui = {
     if (MonHistoire.modules && 
         MonHistoire.modules.stories && 
         MonHistoire.modules.stories.display) {
-      const histoire = MonHistoire.modules.stories.display.getHistoireAffichee();
+      let histoire = MonHistoire.modules.stories.display.getHistoireAffichee();
+
+      // Fallback vers l'ancien namespace si aucune histoire n'est trouvée
+      if (histoire === null &&
+          MonHistoire.features &&
+          MonHistoire.features.stories &&
+          MonHistoire.features.stories.display &&
+          typeof MonHistoire.features.stories.display.getHistoireAffichee === "function") {
+        console.warn("[Partage] Utilisation du fallback getHistoireAffichee depuis MonHistoire.features");
+        histoire = MonHistoire.features.stories.display.getHistoireAffichee();
+      }
       
       // Si aucune histoire n'est affichée, on ne fait rien
       if (!histoire || (!histoire.chapitre1 && !histoire.contenu)) {


### PR DESCRIPTION
## Summary
- check for fallback story getter in export and sharing modules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540ac24854832cbf94fc4b59959574