### PR TITLE
Fix modal close on startup

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -57,3 +57,16 @@ MonHistoire.ui = {
 };
 
 window.MonHistoire = MonHistoire;
+
+// S'assurer que le bouton de fermeture du message modal fonctionne
+// même si les adaptateurs ne sont pas encore initialisés.
+document.addEventListener('DOMContentLoaded', () => {
+  const closeBtn = document.getElementById('close-message-modal');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      if (typeof MonHistoire.closeMessageModal === 'function') {
+        MonHistoire.closeMessageModal();
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- ensure the close button for message modal works as soon as the DOM is ready

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540ac2ac84832c8de55f4a867bf3f8