### PR TITLE
Add story validation in PDF export

### DIFF
--- a/js/features/export.js
+++ b/js/features/export.js
@@ -80,6 +80,13 @@ MonHistoire.features.export = {
   async genererPDF() {
     // Récupère l'histoire affichée
     const histoire = MonHistoire.features.stories.display.getHistoireAffichee();
+
+    if (!histoire) {
+      if (MonHistoire.showMessageModal) {
+        MonHistoire.showMessageModal("Aucune histoire à exporter.");
+      }
+      return;
+    }
     
     // Crée un nouveau document PDF
     const { jsPDF } = window.jspdf;

--- a/js/modules/features/export.js
+++ b/js/modules/features/export.js
@@ -85,13 +85,21 @@ MonHistoire.modules.features.export = {
       MonHistoire.modules.stories.display.getCurrentStory();
 
     // Fallback vers l'ancien namespace si aucune histoire n'est trouvée
-    if (histoire === null &&
+    if (!histoire &&
         MonHistoire.features &&
         MonHistoire.features.stories &&
         MonHistoire.features.stories.display &&
         typeof MonHistoire.features.stories.display.getHistoireAffichee === "function") {
       console.warn("[Export] Utilisation du fallback getHistoireAffichee depuis MonHistoire.features");
       histoire = MonHistoire.features.stories.display.getHistoireAffichee();
+    }
+
+    // Vérifie qu'une histoire a été récupérée
+    if (!histoire) {
+      if (MonHistoire.showMessageModal) {
+        MonHistoire.showMessageModal("Aucune histoire à exporter.");
+      }
+      return;
     }
     
     // Crée un nouveau document PDF


### PR DESCRIPTION
## Summary
- ensure export modules handle missing stories gracefully
- show a message when no story is available for export in both export modules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541e488a48832cb40b442c4e5ae2e9