### PR TITLE
Fix saveStory calls in UI

### DIFF
--- a/js/modules/ui/common.js
+++ b/js/modules/ui/common.js
@@ -288,7 +288,11 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
     // Bouton Sauvegarder Histoire (protégé contre les clics multiples)
     protegerBouton("btn-sauvegarde", () => {
       if (MonHistoire.modules.stories && MonHistoire.modules.stories.management) {
-        MonHistoire.modules.stories.management.sauvegarderHistoire();
+        const storyGetter =
+          MonHistoire.modules.stories.display &&
+          MonHistoire.modules.stories.display.getCurrentStory;
+        const story = typeof storyGetter === "function" ? storyGetter() : null;
+        MonHistoire.modules.stories.management.saveStory(story);
       }
     });
     

--- a/js/modules/ui/events.js
+++ b/js/modules/ui/events.js
@@ -114,7 +114,11 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
 
     protegerBouton('btn-sauvegarde', () => {
       if (MonHistoire.modules.stories && MonHistoire.modules.stories.management) {
-        MonHistoire.modules.stories.management.sauvegarderHistoire();
+        const storyGetter =
+          MonHistoire.modules.stories.display &&
+          MonHistoire.modules.stories.display.getCurrentStory;
+        const story = typeof storyGetter === 'function' ? storyGetter() : null;
+        MonHistoire.modules.stories.management.saveStory(story);
       }
     });
 


### PR DESCRIPTION
## Summary
- update `events.js` and `common.js` to use `saveStory` instead of `sauvegarderHistoire`
- pass the currently displayed story to `saveStory`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541e4be730832cb8456d659ffc8d84