### PR TITLE
Fix share modal content check

### DIFF
--- a/js/modules/sharing/ui.js
+++ b/js/modules/sharing/ui.js
@@ -46,9 +46,14 @@ MonHistoire.modules.sharing.ui = {
         histoire = MonHistoire.features.stories.display.getHistoireAffichee();
       }
       
-      // Si aucune histoire n'est affichée, on ne fait rien
-      if (!histoire || (!histoire.chapitre1 && !histoire.contenu)) {
-        MonHistoire.showMessageModal("Aucune histoire à partager.");
+      // Vérifier qu'il existe du contenu dans l'histoire avant de poursuivre
+      const hasChapitresFields = histoire.chapitre1 || histoire.chapitre2 ||
+        histoire.chapitre3 || histoire.chapitre4 || histoire.chapitre5;
+      const hasChapitresArray = Array.isArray(histoire.chapitres) &&
+        histoire.chapitres.length > 0;
+      const hasContenu = histoire.contenu;
+      if (!histoire || !(hasChapitresFields || hasChapitresArray || hasContenu)) {
+        MonHistoire.showMessageModal("Aucun contenu dans l'histoire à partager.");
         return;
       }
 


### PR DESCRIPTION
## Summary
- correctly handle stories that store text in chapter fields, `chapitres[]` or `contenu`
- show a clearer message when the story has no content

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541e4f26dc832c91552f1680fe31ae