### PR TITLE
Fix adapter initialization and test loading

### DIFF
--- a/js/adapters/profiles-adapter.js
+++ b/js/adapters/profiles-adapter.js
@@ -568,5 +568,9 @@
   }
   
   // Exécuter l'initialisation au chargement de la page
-  document.addEventListener('DOMContentLoaded', init);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 })();

--- a/tests/adapters-index.test.js
+++ b/tests/adapters-index.test.js
@@ -1,0 +1,28 @@
+const { JSDOM } = require('jsdom');
+
+describe('adapters index loader', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('', { url: 'http://localhost' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+  });
+
+  test('profiles-adapter is requested', () => {
+    const sources = [];
+    const originalAppendChild = document.head.appendChild.bind(document.head);
+    document.head.appendChild = (el) => {
+      if (el.src) sources.push(el.src);
+      return originalAppendChild(el);
+    };
+
+    require('../js/adapters/index.js');
+
+    expect(sources).toContain('js/adapters/profiles-adapter.js');
+  });
+});

--- a/tests/profiles-adapter-export.test.js
+++ b/tests/profiles-adapter-export.test.js
@@ -1,0 +1,24 @@
+const { JSDOM } = require('jsdom');
+
+describe('profiles adapter export', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM('<!DOCTYPE html><div id="logout-modal"></div><div id="logout-profiles-list"></div><div id="logout-profile-name"></div>', { url: 'http://localhost' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.firebase = { auth: () => ({ currentUser: null }) };
+    global.MonHistoire = {};
+  });
+
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.firebase;
+    delete global.MonHistoire;
+  });
+
+  test('defines ouvrirLogoutModal', () => {
+    require('../js/adapters/profiles-adapter.js');
+    expect(typeof window.MonHistoire.ouvrirLogoutModal).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure profiles adapter initializes even when loaded after DOMContentLoaded
- test that adapters/index.js injects `profiles-adapter.js`
- test that `MonHistoire.ouvrirLogoutModal` is exported

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541e5af81c832c8322c30511ded44a