### PR TITLE
Sync profile state across modules

### DIFF
--- a/js/modules/app.js
+++ b/js/modules/app.js
@@ -11,7 +11,6 @@ MonHistoire.modules = MonHistoire.modules || {};
   // Variables privées
   let isInitialized = false;
   let currentScreen = null;
-  let currentProfile = null;
   
   /**
    * Initialise le module principal
@@ -324,7 +323,7 @@ MonHistoire.modules = MonHistoire.modules || {};
     }
     
     if (createStoryButton) {
-      createStoryButton.classList.toggle('hidden', !isLoggedIn || !currentProfile);
+      createStoryButton.classList.toggle('hidden', !isLoggedIn || !MonHistoire.state.profilActif);
     }
     
     if (settingsButton) {
@@ -377,7 +376,7 @@ MonHistoire.modules = MonHistoire.modules || {};
           option.value = profile.id;
           option.textContent = profile.name;
           
-          if (currentProfile && profile.id === currentProfile.id) {
+          if (MonHistoire.state.profilActif && profile.id === MonHistoire.state.profilActif.id) {
             option.selected = true;
           }
           
@@ -408,7 +407,7 @@ MonHistoire.modules = MonHistoire.modules || {};
         MonHistoire.modules.user.profiles.getCurrentProfile()
           .then(profile => {
             if (profile) {
-              currentProfile = profile;
+              MonHistoire.state.profilActif = profile;
               
               // Émettre un événement pour informer que le profil est sélectionné
               if (MonHistoire.events) {
@@ -430,7 +429,7 @@ MonHistoire.modules = MonHistoire.modules || {};
       console.log("Utilisateur déconnecté");
       
       // Réinitialiser le profil courant
-      currentProfile = null;
+      MonHistoire.state.profilActif = null;
       
       // Naviguer vers l'écran de connexion
       if (MonHistoire.modules.core && MonHistoire.modules.core.navigation) {
@@ -445,7 +444,7 @@ MonHistoire.modules = MonHistoire.modules || {};
    * @param {Object} profile - Profil sélectionné
    */
   function handleProfileSelected(profile) {
-    currentProfile = profile;
+    MonHistoire.state.profilActif = profile;
     
     // Mettre à jour l'interface utilisateur
     updateHeaderState();
@@ -470,8 +469,8 @@ MonHistoire.modules = MonHistoire.modules || {};
    */
   function handleProfileUpdated(profile) {
     // Mettre à jour le profil courant si nécessaire
-    if (currentProfile && profile.id === currentProfile.id) {
-      currentProfile = profile;
+    if (MonHistoire.state.profilActif && profile.id === MonHistoire.state.profilActif.id) {
+      MonHistoire.state.profilActif = profile;
     }
     
     // Mettre à jour le sélecteur de profil
@@ -486,8 +485,8 @@ MonHistoire.modules = MonHistoire.modules || {};
    */
   function handleProfileDeleted(profileId) {
     // Réinitialiser le profil courant si nécessaire
-    if (currentProfile && profileId === currentProfile.id) {
-      currentProfile = null;
+    if (MonHistoire.state.profilActif && profileId === MonHistoire.state.profilActif.id) {
+      MonHistoire.state.profilActif = null;
     }
     
     // Mettre à jour le sélecteur de profil
@@ -514,7 +513,7 @@ MonHistoire.modules = MonHistoire.modules || {};
       if (MonHistoire.modules.user && MonHistoire.modules.user.profiles) {
         MonHistoire.modules.user.profiles.selectProfile(profileId)
           .then(profile => {
-            currentProfile = profile;
+            MonHistoire.state.profilActif = profile;
             
             // Émettre un événement pour informer que le profil est sélectionné
             if (MonHistoire.events) {
@@ -660,7 +659,7 @@ MonHistoire.modules = MonHistoire.modules || {};
    */
   function handleCreateStory() {
     // Vérifier si un profil est sélectionné
-    if (!currentProfile) {
+    if (!MonHistoire.state.profilActif) {
       if (MonHistoire.showWarning) {
         MonHistoire.showWarning("Veuillez sélectionner un profil pour créer une histoire.");
       }
@@ -709,7 +708,7 @@ MonHistoire.modules = MonHistoire.modules || {};
    * @returns {Object} Profil sélectionné ou null
    */
   function getCurrentProfile() {
-    return currentProfile;
+    return MonHistoire.state.profilActif;
   }
   
   /**

--- a/js/modules/stories/generator.js
+++ b/js/modules/stories/generator.js
@@ -10,7 +10,6 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
 // Module de génération d'histoires
 (function() {
   // Variables privées
-  let currentProfile = null;
   let currentTemplate = null;
   let templates = [];
   let formData = {};
@@ -95,7 +94,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
    * @param {Object} profile - Profil sélectionné
    */
   function handleProfileChange(profile) {
-    currentProfile = profile;
+    MonHistoire.state.profilActif = profile;
     
     // Mettre à jour l'interface utilisateur
     updateFormUI();
@@ -233,8 +232,8 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
                 input.value = field.defaultValue;
               }
               // Si le champ est lié au profil, pré-remplir avec les informations du profil
-              if (field.profileField && currentProfile) {
-                input.value = currentProfile[field.profileField] || '';
+              if (field.profileField && MonHistoire.state.profilActif) {
+                input.value = MonHistoire.state.profilActif[field.profileField] || '';
               }
               break;
               
@@ -266,8 +265,8 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
               }
               
               // Si le champ est lié au profil, pré-sélectionner l'option correspondante
-              if (field.profileField && currentProfile) {
-                const profileValue = currentProfile[field.profileField];
+              if (field.profileField && MonHistoire.state.profilActif) {
+                const profileValue = MonHistoire.state.profilActif[field.profileField];
                 if (profileValue) {
                   input.value = profileValue;
                 }
@@ -295,8 +294,8 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
                   radioLabel.textContent = option.label;
                   
                   // Si le champ est lié au profil, pré-sélectionner l'option correspondante
-                  if (field.profileField && currentProfile) {
-                    const profileValue = currentProfile[field.profileField];
+                  if (field.profileField && MonHistoire.state.profilActif) {
+                    const profileValue = MonHistoire.state.profilActif[field.profileField];
                     if (profileValue === option.value) {
                       radioInput.checked = true;
                     }
@@ -426,7 +425,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
    * Gère la génération d'une histoire
    */
   function handleGenerateStory() {
-    if (!currentTemplate || !currentProfile) {
+    if (!currentTemplate || !MonHistoire.state.profilActif) {
       if (MonHistoire.showMessageModal) {
         MonHistoire.showMessageModal("Veuillez sélectionner un template et un profil.");
       }
@@ -463,7 +462,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
     // Préparer les données pour la génération
     const generationData = {
       templateId: currentTemplate.id,
-      profileId: currentProfile.id,
+      profileId: MonHistoire.state.profilActif.id,
       formData: formData
     };
     
@@ -659,10 +658,10 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
           // Créer une histoire de test
           const story = {
             id: `story-${Date.now()}`,
-            title: `Histoire de ${data.formData.heroName || currentProfile.prenom}`,
+            title: `Histoire de ${data.formData.heroName || MonHistoire.state.profilActif.prenom}`,
             content: generateStoryContent(template, data.formData),
             templateId: template.id,
-            profileId: currentProfile.id,
+            profileId: MonHistoire.state.profilActif.id,
             createdAt: new Date().toISOString(),
             formData: data.formData
           };
@@ -853,8 +852,8 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
     }
     
     // Remplacer les variables du profil
-    if (currentProfile) {
-      for (const [key, value] of Object.entries(currentProfile)) {
+    if (MonHistoire.state.profilActif) {
+      for (const [key, value] of Object.entries(MonHistoire.state.profilActif)) {
         if (typeof value === 'string') {
           content = content.replace(new RegExp(`\\{profile\\.${key}\\}`, 'g'), value);
         }

--- a/js/modules/stories/management.js
+++ b/js/modules/stories/management.js
@@ -11,7 +11,6 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
 (function() {
   // Variables privées
   let currentUser = null;
-  let currentProfile = null;
   let stories = [];
   let isInitialized = false;
   
@@ -47,7 +46,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
     
     if (user) {
       // Utilisateur connecté, charger les histoires si un profil est sélectionné
-      if (currentProfile) {
+      if (MonHistoire.state.profilActif) {
         loadStories();
       }
     } else {
@@ -64,8 +63,8 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
    * @param {Object} profile - Profil sélectionné
    */
   function handleProfileChange(profile) {
-    currentProfile = profile;
-    
+    MonHistoire.state.profilActif = profile;
+
     if (currentUser && profile) {
       // Charger les histoires du profil
       loadStories();
@@ -146,7 +145,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
    * Charge les histoires du profil actuel
    */
   function loadStories() {
-    if (!currentUser || !currentProfile) {
+    if (!currentUser || !MonHistoire.state.profilActif) {
       return;
     }
     
@@ -157,7 +156,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
     
     // Utiliser le module de stockage pour récupérer les histoires
     if (MonHistoire.modules.core && MonHistoire.modules.core.storage) {
-      MonHistoire.modules.core.storage.getStories(currentProfile.id)
+      MonHistoire.modules.core.storage.getStories(MonHistoire.state.profilActif.id)
         .then(loadedStories => {
           stories = loadedStories;
           
@@ -539,7 +538,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
    */
   function saveStory(story) {
     return new Promise((resolve, reject) => {
-      if (!currentUser || !currentProfile) {
+      if (!currentUser || !MonHistoire.state.profilActif) {
         reject(new Error("Utilisateur ou profil non défini"));
         return;
       }
@@ -548,7 +547,7 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
       const storyData = {
         ...story,
         userId: currentUser.uid,
-        profileId: currentProfile.id,
+        profileId: MonHistoire.state.profilActif.id,
         createdAt: story.createdAt || new Date().toISOString()
       };
       

--- a/js/modules/user/auth.js
+++ b/js/modules/user/auth.js
@@ -384,12 +384,11 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
     document.getElementById("my-stories-button").classList.remove("ui-hidden");
 
     // → Si un profil enfant est actif, on court-circuite tout :
-    if (MonHistoire.modules && MonHistoire.modules.user && 
-        MonHistoire.modules.user.profiles && 
-        MonHistoire.modules.user.profiles.getCurrentProfile) {
-      
-      const currentProfile = MonHistoire.modules.user.profiles.getCurrentProfile();
-      if (currentProfile && currentProfile.prenom) {
+    if (MonHistoire.state && MonHistoire.state.profilActif &&
+        MonHistoire.state.profilActif.type === 'enfant') {
+
+      const currentProfile = MonHistoire.state.profilActif;
+      if (currentProfile.prenom) {
         // On met directement l'initiale de l'enfant
         document.getElementById("user-icon").textContent = currentProfile.prenom
           .trim()

--- a/js/modules/user/profiles.js
+++ b/js/modules/user/profiles.js
@@ -217,7 +217,7 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
     
     // Mettre à jour l'état global
     if (MonHistoire.state) {
-      MonHistoire.state.currentProfile = currentProfile;
+      MonHistoire.state.profilActif = currentProfile;
     }
   }
   
@@ -227,15 +227,26 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
    */
   function selectProfile(profile) {
     currentProfile = profile;
-    
+
+    // Mettre à jour l'état global et le stockage local
+    if (MonHistoire.state) {
+      MonHistoire.state.profilActif = profile;
+    }
+    localStorage.setItem('profilActif', JSON.stringify(profile));
+
     // Mettre à jour l'interface utilisateur
     updateUI();
-    
+
+    // Mettre à jour la visibilité du footer si disponible
+    if (typeof MonHistoire.updateFooterVisibility === 'function') {
+      MonHistoire.updateFooterVisibility();
+    }
+
     // Émettre un événement pour informer les autres modules
     if (MonHistoire.events) {
       MonHistoire.events.emit('profileSelected', profile);
     }
-    
+
     console.log(`Profil sélectionné: ${profile.prenom}`);
   }
   


### PR DESCRIPTION
## Summary
- update user `selectProfile` to persist to `profilActif` and localStorage
- use global `MonHistoire.state.profilActif` in App module
- sync profile state in story generator and management modules
- display user icon based on `profilActif`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685437a40aa0832ca5b1675fc66d8031