### PR TITLE
Fix currentStory assignment when generating stories

### DIFF
--- a/js/adapters/stories-adapter.js
+++ b/js/adapters/stories-adapter.js
@@ -194,12 +194,15 @@
       
       genererHistoire: function(params) {
         console.log("[Adapter] Redirection de genererHistoire vers modules.stories.generator.generateStory");
-        // Si des paramètres sont fournis, les utiliser, sinon laisser le module récupérer les valeurs du formulaire
-        if (params) {
-          return MonHistoire.modules.stories.generator.generateStory(params);
-        } else {
-          return MonHistoire.modules.stories.generator.generateStory();
-        }
+        const promise = params ?
+          MonHistoire.modules.stories.generator.generateStory(params) :
+          MonHistoire.modules.stories.generator.generateStory();
+        return promise.then(story => {
+          if (story && MonHistoire.modules.stories && MonHistoire.modules.stories.display) {
+            MonHistoire.modules.stories.display.showStory(story);
+          }
+          return story;
+        });
       }
     };
     

--- a/js/modules/stories/generator.js
+++ b/js/modules/stories/generator.js
@@ -468,12 +468,17 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
     };
     
     // Générer l'histoire
-    generateStory(generationData)
-      .then(story => {
-        generatedStory = story;
-        
-        // Mettre à jour l'interface utilisateur
-        updateResultUI();
+      generateStory(generationData)
+        .then(story => {
+          generatedStory = story;
+
+          // Assure la disponibilité de l'histoire pour l'export ou le partage
+          if (MonHistoire.modules.stories && MonHistoire.modules.stories.display) {
+            MonHistoire.modules.stories.display.showStory(generatedStory);
+          }
+
+          // Mettre à jour l'interface utilisateur
+          updateResultUI();
         
         // Masquer le chargement
         if (MonHistoire.modules.app && MonHistoire.modules.app.showLoading) {
@@ -965,6 +970,11 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
           }
 
           histoireElement.innerHTML = histoire.displayHtml;
+
+          // Mettre à disposition l'histoire pour les autres modules
+          if (MonHistoire.modules.stories && MonHistoire.modules.stories.display) {
+            MonHistoire.modules.stories.display.showStory(generatedStory);
+          }
         })
         .catch(error => {
           console.error("Erreur lors de la génération de l'histoire:", error);


### PR DESCRIPTION
## Summary
- update `showStory` usage in generator so exported/sharing features see the story
- ensure adapters assign `currentStory` after generating a story

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685437a9379c832cbac9831174a9a48d