### PR TITLE
Fix sharing content property check

### DIFF
--- a/js/modules/sharing/ui.js
+++ b/js/modules/sharing/ui.js
@@ -51,7 +51,7 @@ MonHistoire.modules.sharing.ui = {
         histoire.chapitre3 || histoire.chapitre4 || histoire.chapitre5;
       const hasChapitresArray = Array.isArray(histoire.chapitres) &&
         histoire.chapitres.length > 0;
-      const hasContenu = histoire.contenu;
+      const hasContenu = histoire.contenu || histoire.content;
       if (!histoire || !(hasChapitresFields || hasChapitresArray || hasContenu)) {
         MonHistoire.showMessageModal("Aucun contenu dans l'histoire à partager.");
         return;


### PR DESCRIPTION
## Summary
- broaden content property check to work with `content`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543e3e6c0c832c811f960a399e3aa2