### PR TITLE
Fix reset password when Auth not initialized

### DIFF
--- a/js/modules/user/auth.js
+++ b/js/modules/user/auth.js
@@ -188,6 +188,11 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
       
       // Vérifier si Firebase Auth est initialisé
       if (!auth) {
+        // Tenter une initialisation si ce n'est pas déjà fait
+        init();
+      }
+
+      if (!auth) {
         console.error("Firebase Auth n'est pas initialisé");
         reject(new Error("Service d'authentification non disponible"));
         return;
@@ -499,6 +504,11 @@ MonHistoire.modules.user = MonHistoire.modules.user || {};
     }
     
     // Vérifier si Firebase Auth est initialisé
+    if (!auth) {
+      // Tenter une initialisation si ce n'est pas déjà fait
+      init();
+    }
+
     if (!auth) {
       console.error("Firebase Auth n'est pas initialisé");
       if (MonHistoire.showMessageModal) {


### PR DESCRIPTION
## Summary
- initialize Firebase Auth if needed before calling resetPassword or sendReset

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685469c1e1fc832caf209478295216bb