### PR TITLE
Fix current user initialization in storage module

### DIFF
--- a/js/modules/core/storage.js
+++ b/js/modules/core/storage.js
@@ -60,6 +60,11 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
       if (MonHistoire.events) {
         MonHistoire.events.on('authStateChange', handleAuthStateChange);
       }
+
+      // Récupérer l'utilisateur actuellement authentifié si disponible
+      if (firebase.auth) {
+        currentUser = firebase.auth().currentUser;
+      }
       
       isInitialized = true;
       console.log("Module Storage initialisé");
@@ -85,9 +90,17 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
    */
   function _checkAuth() {
     if (!currentUser) {
+      if (firebase.auth) {
+        const user = firebase.auth().currentUser;
+        if (user) {
+          currentUser = user;
+        }
+      }
+    }
+    if (!currentUser) {
       throw new Error("Utilisateur non authentifié");
     }
-    
+
     return true;
   }
   


### PR DESCRIPTION
## Summary
- update `init` to capture any already authenticated user
- extend `_checkAuth` to re-check Firebase auth when needed

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685470b70198832ca445844580b022a2