### PR TITLE
Handle missing user in saveStory

### DIFF
--- a/js/modules/stories/management.js
+++ b/js/modules/stories/management.js
@@ -545,7 +545,12 @@ MonHistoire.modules.stories = MonHistoire.modules.stories || {};
     return new Promise((resolve, reject) => {
       const user = currentUser || (firebase.auth && firebase.auth().currentUser);
       if (!user || !MonHistoire.state.profilActif) {
-        reject(new Error("Utilisateur ou profil non défini"));
+        if (MonHistoire.showMessageModal) {
+          MonHistoire.showMessageModal(
+            "Vous devez être connecté et avoir un profil sélectionné."
+          );
+        }
+        resolve();
         return;
       }
       


### PR DESCRIPTION
## Summary
- show a modal if `saveStory` is called without an authenticated user or selected profile

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685470d0d284832cac50fda286e27d65