### PR TITLE
Handle uninitialized DB in saveStory

### DIFF
--- a/js/modules/core/storage.js
+++ b/js/modules/core/storage.js
@@ -483,6 +483,14 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
    */
   function saveStory(storyData) {
     return new Promise((resolve, reject) => {
+      if (!isInitialized) {
+        init();
+      }
+      if (!db) {
+        console.error("Firestore n'est pas initialisé");
+        reject(new Error("Service de stockage non disponible"));
+        return;
+      }
       try {
         _checkAuth();
         


### PR DESCRIPTION
## Summary
- ensure Storage module initializes Firestore before saving a story
- fail fast if Firestore is unavailable

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854741bb418832cbdb1f4144e8549f9