### PR TITLE
Ensure story document retrieval via ID

### DIFF
--- a/js/modules/core/storage.js
+++ b/js/modules/core/storage.js
@@ -176,6 +176,20 @@ MonHistoire.modules.core = MonHistoire.modules.core || {};
   }
 
   /**
+   * Retourne l'ID du profil actif s'il existe
+   * @returns {string|null} ID du profil actif ou null
+   * @private
+   */
+  function _getActiveProfileId() {
+    const profilActif = (MonHistoire.state && MonHistoire.state.profilActif) ||
+      (localStorage.getItem('profilActif') ? JSON.parse(localStorage.getItem('profilActif')) : null);
+    if (profilActif && profilActif.type === 'enfant') {
+      return profilActif.id;
+    }
+    return null;
+  }
+
+  /**
    * Retourne la référence de collection des histoires pour l'utilisateur courant
    * @param {string} [profileId] - ID du profil enfant le cas échéant
    * @returns {Object} Référence de collection Firestore


### PR DESCRIPTION
## Summary
- add `_getActiveProfileId` helper for other features
- use `_getStoryDocRef` in core storage operations

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685484440984832c93fc2626ef2e1f8b