### PR TITLE
Remove outdated features branch from rename handler

### DIFF
--- a/js/modules/ui/events.js
+++ b/js/modules/ui/events.js
@@ -186,8 +186,6 @@ MonHistoire.modules.ui = MonHistoire.modules.ui || {};
         await MonHistoire.modules.core?.storage?.updateStoryTitle(id, newTitle);
         if (MonHistoire.modules.stories?.management?.loadStories) {
           MonHistoire.modules.stories.management.loadStories();
-        } else if (MonHistoire.features?.stories?.management?.afficherHistoiresSauvegardees) {
-          MonHistoire.features.stories.management.afficherHistoiresSauvegardees();
         }
       } catch (error) {
         console.error('Erreur lors du renommage:', error);


### PR DESCRIPTION
## Summary
- simplify rename confirmation logic
- remove leftover references to deprecated `MonHistoire.features`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548cd4c0a0832c94e56d5e19937d3a