### PR TITLE
Fix logging parameters for Firestore

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -239,7 +239,7 @@ MonHistoire.logger = {
 
 // Gestion de la reconnexion
 MonHistoire.handleReconnection = function() {
-  MonHistoire.logger.info("Connexion rétablie");
+  MonHistoire.logger.info(MonHistoire.logger.PREFIXES.CONNECTION, "Connexion rétablie");
   
   // Mettre à jour l'état de connexion
   MonHistoire.state.isConnected = true;
@@ -269,7 +269,7 @@ MonHistoire.handleReconnection = function() {
 
 // Gestion de la déconnexion
 MonHistoire.handleDisconnection = function() {
-  MonHistoire.logger.warning("Connexion perdue");
+  MonHistoire.logger.warning(MonHistoire.logger.PREFIXES.CONNECTION, "Connexion perdue");
   MonHistoire.state.isConnected = false;
   
   // Émettre un événement pour informer les autres modules

--- a/js/modules/sharing/storage.js
+++ b/js/modules/sharing/storage.js
@@ -238,10 +238,13 @@ MonHistoire.modules.sharing.storage = {
   async processOfflinePartage(data) {
     try {
       const user = firebase.auth().currentUser;
-      if (!user) {
-        MonHistoire.logger.error("Impossible de traiter le partage hors ligne: utilisateur non connecté");
-        return false;
-      }
+        if (!user) {
+          MonHistoire.logger.error(
+            MonHistoire.logger.PREFIXES.SHARING,
+            "Impossible de traiter le partage hors ligne: utilisateur non connecté"
+          );
+          return false;
+        }
       
       const { type, id, prenom, histoire, profilActif } = data;
       


### PR DESCRIPTION
## Summary
- fix logger usage in connection handlers
- fix logging prefix when offline sharing fails

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548e8eecd0832cb1980e14c4ac4ca3