### PR TITLE
Update messaging snippet for legacy usage

### DIFF
--- a/guide-integration-ui.md
+++ b/guide-integration-ui.md
@@ -262,7 +262,7 @@ Exemple minimal pour déclencher l'ouverture des conversations :
 ```html
 <button id="my-messages-button" class="ui-button ui-button--primary">Mes messages</button>
 <script>
-  // Après chargement des modules messaging
+  // Appel de la fonction héritée d'initialisation
   MonHistoire.features.messaging.ui.init();
 </script>
 ```


### PR DESCRIPTION
## Summary
- update messaging example to reference the legacy initialization

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685541fc721c832cbe7378a39288bf1f