### PR TITLE
Use protegerBouton for register button

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -83,9 +83,9 @@ window.MonHistoire = window.MonHistoire || {};
         MonHistoire.core?.auth?.loginUser?.();
     });
 
-    document.getElementById('btn-register')?.addEventListener('click', (e) => {
+    protegerBouton('btn-register', (e) => {
       e.preventDefault();
-        MonHistoire.core?.auth?.registerUser?.();
+      MonHistoire.core?.auth?.registerUser?.();
     });
 
     document.getElementById('btn-send-reset')?.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- use `protegerBouton` for the registration button binding in `ui.js`
- other Firebase-triggering buttons already use `protegerBouton`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855522c53b0832ca77441cb5f4f920c