### PR TITLE
Handle new child profiles client-side

### DIFF
--- a/js/core/auth.js
+++ b/js/core/auth.js
@@ -475,12 +475,8 @@ MonHistoire.core.auth = {
               `Stock d'histoires : <i>erreur de lecture</i>`;
           });
         
-        // Initialiser les variables pour les profils enfants
-        if (!MonHistoire.state.profilsEnfantModifies) {
-          MonHistoire.state.profilsEnfantModifies = [];
-        }
-        
-        // Afficher les profils enfants
+        // Réinitialiser les modifications et afficher les profils enfants
+        MonHistoire.state.profilsEnfantModifies = [];
         if (typeof MonHistoire.afficherProfilsEnfants === 'function') {
           MonHistoire.afficherProfilsEnfants();
         }


### PR DESCRIPTION
## Summary
- support caching new child profiles before saving
- batch write new profiles to Firestore
- refresh child profile list when account modal opens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558c043cfc832c8c2960c247dc78c5