### PR TITLE
Add Firestore rules and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,3 +451,13 @@ MonHistoire.debug("Message de débogage", data);
 ## Conclusion
 
 Cette nouvelle architecture modulaire offre une base solide pour le développement futur de l'application "Mon Histoire". Elle facilite la maintenance, l'évolution et la collaboration entre développeurs.
+
+## Déploiement des Règles Firestore
+
+Un fichier `firestore.rules` est présent à la racine du projet. Il définit les règles de sécurité permettant aux utilisateurs authentifiés d'accéder à leurs propres données sous `users/{userId}` et dans toutes les sous-collections (par exemple `stories` ou `profils_enfant/{profilId}/stories`).
+
+Pour déployer ces règles vers votre projet Firebase, utilisez la commande suivante après avoir installé les Firebase Tools :
+
+```bash
+firebase deploy --only firestore:rules
+```

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Les utilisateurs authentifiés peuvent lire et écrire leurs propres données
+    // dans /users/{userId} ainsi que dans toutes les sous-collections
+    match /users/{userId}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firebase security rules for authenticated user data
- document how to deploy these rules with Firebase tools

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68568274aee4832cb61391eed8613715