### PR TITLE
Fix background color for rename modal

### DIFF
--- a/css/components/modals.css
+++ b/css/components/modals.css
@@ -71,6 +71,10 @@
   background-color: #fffef9 !important;
 }
 
+#modal-renommer .ui-modal-content {
+  background-color: #fff8e1 !important;
+}
+
 #message-modal .bloc-centre {
   width: 60%;
   max-width: 400px;


### PR DESCRIPTION
## Summary
- update modal styles so the rename modal uses the cream background

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857c1d01494832cb1040da88a5bb145